### PR TITLE
Updates to close POA&M 2020-V0070-SA-11 by restoring compliance guidance

### DIFF
--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -1,35 +1,68 @@
 # Story lifecycle
 
-**Stories** Stories and issues are created to capture work that needs to be done by the team. Our goal is to create multiple smaller stories that can be worked on incrementally rather than one large story that takes significant time to complete.
-Our team utilizes four swimlanes to manage our work.
+**Compliance Note**: This document partially fulfills [SA-11](https://nvd.nist.gov/800-53/Rev4/control/SA-11). All updates should ensure we maintain security assessments throughout the story and feature lifecycle, and other comply with our our System Security Plan.
+
+## Stories
+
+Stories and issues are created to capture work that needs to be done by the team. Our goal is to create multiple smaller stories that can be worked on incrementally rather than one large story that takes significant time to complete.
+Our team utilizes four swimlanes of "groomed" storeis to manage our work.
+
+**Story Definition**: Groomed stories that accepted for the backlog should include:
+
+* A clear "definition of done" or "acceptance criteria" (AC) so the team understands when work is complete
+* A reviewed "Security Considerations" section. Especially ensure any authentication/authorization and data persistence points are discussed and requirements are addressed via Acceptance Criteria (e.g., "Authenticate using [login.fr.cloud.gov]" or "Any ephemeral data resulting from usage is backed up/recoverable").
+
+Required for compliance:
+
+* If necessary, the story includes a security testing plan. For example, the ACs include automated tests and alerts for unexpected behavior.
+* If a story is a _feature_ added to the cloud.gov system, then it requires a _*security impact analysis*_ as we ensure every feature undergoes compliance oversight:
+
+  * We've reviewed the feature for impact according to our [significant change rubric](https://cloud.gov/docs/ops/continuous-monitoring/#appendix-significant-change-rubric).
+  * We summarize the feature for the JAB Technical Reviewers in (or in a doc linked from) the [agenda for the next bi-weekly JAB Technical Reviewers meeting](https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit#).
+  
+    * We've received a determination from the JAB Technical Reviewers as to whether they agree a Significant Change Request (SCR) is warranted. If the determination is "yes", the card is tagged with `SCR:Yes`. Otherwise the card is tagged with `SCR:No`.
+    * If the card is tagged `SCR:Yes`:
+    * The feature should include a story covering delivery of a [Significant Change Request](https://docs.google.com/a/gsa.gov/document/d/16GaDO1xnHrqEEetbonNpo4P10LlGoDHR-jedqBo1yB8/edit?usp=drive_web) in [Google Drive](https://drive.google.com/drive/folders/0B1cewEqKcWCbU1lSUXhEVUNZWUU).
+    * The SCR is submitted to the JAB Technical Reviewers (with 3PAO testing results if necessary).
+    * The JAB Technical Reviewers have approved the SCR.
+
+Compliance control notes:
+
+* Security impact analysis is due to CM-3 part b, CM-4
+* New software integration check is due to CM-7 (5) part a
+* Security test planning is due to SA-11 part a
+
+## Swimlanes
+
+### Backlog
+
+* Prioritized and groomed stories/issues. 
+* **Entrance**: Weekly prioritization meeting reviews and prioritizes stories to develop a list in rank order of the 10 highest priorities stories/issues.
+* **Exit**: The team pulls the next thing to work on from the top of the backlog and into the doing swimlane.
+
+### Doing
+
+* Stories/issues that are in progress/actively being worked on.
+* **Entrance**: Team members pull a story into the doing column from the backlog when they begin work on a given story/issue.
+* **Exit**: Stories/issues are moved to the closed swimlane once they are complete.
+
+Required for compliance:
+
+* The deployment must follow our [Configuration Management plan](https://docs.cloud.gov/ops/configuration-management/).  If not possible, contact the Program Management team to modify the story or discuss how to update the Configuration Management plan.  
+* If the deployment includes 18F-developed code, ensure the repository is configured to run [Code Climate static analysis on each PR](https://docs.codeclimate.com/docs/github#pull-requests).
+
+  * Code Climate scan results are reviewed, and any false positives are flagged / scanning rules are updated to exclude irrelevant files (vendored code, tests, etc).
+* The work completed adheres to all of [cloud.gov's policies and procedures](https://github.com/18F/compliance-docs).
+* If the work changes an aspect of our system or operating environment that is (or should be) documented in our System Security Plan (SSP), [note necessary changes in our pending SSP change document](https://docs.google.com/a/gsa.gov/document/d/1CWi8efCQKi6TS5oxm76YpSvx3pyQMiW-F0i7lIsdBXk/edit?usp=drive_web) to note the change.
 
 
-## Backlog
 
-- Prioritized and groomed stories/issues. 
-- **Entrance**: Weekly prioritization meeting reviews and prioritizes stories to develop a list in rank order of the 10 highest priorities stories/issues.
-- **Exit**: The team pulls the next thing to work on from the top of the backlog and into the doing swimlane.
+### Blocked
 
+* Work that is blocked by internal or external entities.
+* **Entrance**: Stories or issues are moved to blocked if the team is being prevented from completing the work.
+* **Exit**: Stories or issues are moved out of blocked once the blocker has been resolved.
 
-## Doing
-
-- Stories/issues that are in progress/actively being worked on.
-- **Entrance**: Team members pull a story into the doing column from the backlog when they begin work on a given story/issue.
-- **Exit**: Stories/issues are moved to the closed swimlane once they are complete.
-
-
-## Blocked
-
-- Work that is blocked by internal or external entities.
-- **Entrance**: Stories or issues are moved to blocked if the team is being prevented from completing the work.
-- **Exit**: Stories or issues are moved out of blocked once the blocker has been resolved.
-
-## Closed
+### Closed
 
 **Entrance**: Team members move stories/issues to the close swimlane once the work is complete (satisfy the acceptance criteria) OR stories/issues are no longer relevant or a priority.
-
-Related controls: CM-4, CM-9, CM-11, SC-18
-
-
-
-

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -32,7 +32,7 @@ Compliance control notes:
 * New software integration check is due to CM-7 (5) part a
 * Security test planning is due to SA-11 part a
 
-## Swimlanes
+## Swim Lanes
 
 ### Backlog
 

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -5,7 +5,7 @@
 ## Stories
 
 Stories and issues are created to capture work that needs to be done by the team. Our goal is to create multiple smaller stories that can be worked on incrementally rather than one large story that takes significant time to complete.
-Our team utilizes four swimlanes of "groomed" storeis to manage our work.
+Our team utilizes four swim lanes of "groomed" stories to manage our work.
 
 **Story Definition**: Groomed stories that accepted for the backlog should include:
 

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -4,10 +4,11 @@
 
 ## Stories
 
-Stories and issues are created to capture work that needs to be done by the team. Our goal is to create multiple smaller stories that can be worked on incrementally rather than one large story that takes significant time to complete.
+Stories and issues are created to capture work that might need be done by the team. Our goal is to create multiple smaller stories that can be worked on incrementally rather than one large story that takes significant time to complete. Groomed work in the backlog we agree needs to be done.
+
 Our team utilizes four swim lanes of "groomed" stories to manage our work.
 
-**Story Definition**: Groomed stories that accepted for the backlog should include:
+**Story Definition**: Groomed stories that we accept for the backlog should include:
 
 * A clear "definition of done" or "acceptance criteria" (AC) so the team understands when work is complete
 * A reviewed "Security Considerations" section. Especially ensure any authentication/authorization and data persistence points are discussed and requirements are addressed via Acceptance Criteria (e.g., "Authenticate using [login.fr.cloud.gov]" or "Any ephemeral data resulting from usage is backed up/recoverable").
@@ -36,26 +37,24 @@ Compliance control notes:
 
 ### Backlog
 
-* Prioritized and groomed stories/issues. 
+* Prioritized and groomed stories/issues.
 * **Entrance**: Weekly prioritization meeting reviews and prioritizes stories to develop a list in rank order of the 10 highest priorities stories/issues.
-* **Exit**: The team pulls the next thing to work on from the top of the backlog and into the doing swimlane.
+* **Exit**: The team pulls the next thing to work on from the top of the backlog and into the doing swim lane.
 
 ### Doing
 
 * Stories/issues that are in progress/actively being worked on.
 * **Entrance**: Team members pull a story into the doing column from the backlog when they begin work on a given story/issue.
-* **Exit**: Stories/issues are moved to the closed swimlane once they are complete.
+* **Exit**: Stories/issues are moved to the closed swim lane once they are complete.
 
 Required for compliance:
 
-* The deployment must follow our [Configuration Management plan](https://docs.cloud.gov/ops/configuration-management/).  If not possible, contact the Program Management team to modify the story or discuss how to update the Configuration Management plan.  
-* If the deployment includes 18F-developed code, ensure the repository is configured to run [Code Climate static analysis on each PR](https://docs.codeclimate.com/docs/github#pull-requests).
+* The deployment must follow our [Configuration Management plan](https://cloud.gov/docs/ops/configuration-management/).  If not possible, contact the Program Management team to modify the story or discuss how to update the Configuration Management plan.  
+* If the deployment includes cloud.gov-developed code, ensure the repository is configured to run [Code Climate static analysis on each PR](https://docs.codeclimate.com/docs/github#pull-requests).
 
   * Code Climate scan results are reviewed, and any false positives are flagged / scanning rules are updated to exclude irrelevant files (vendored code, tests, etc).
-* The work completed adheres to all of [cloud.gov's policies and procedures](https://github.com/18F/compliance-docs).
+* The work completed adheres to all of [cloud.gov's policies and procedures](https://github.com/cloud-gov/compliance-docs).
 * If the work changes an aspect of our system or operating environment that is (or should be) documented in our System Security Plan (SSP), [note necessary changes in our pending SSP change document](https://docs.google.com/a/gsa.gov/document/d/1CWi8efCQKi6TS5oxm76YpSvx3pyQMiW-F0i7lIsdBXk/edit?usp=drive_web) to note the change.
-
-
 
 ### Blocked
 
@@ -65,4 +64,10 @@ Required for compliance:
 
 ### Closed
 
-**Entrance**: Team members move stories/issues to the close swimlane once the work is complete (satisfy the acceptance criteria) OR stories/issues are no longer relevant or a priority.
+**Entrance**: Team members move stories/issues to the close swim lane once the work is complete (satisfy the acceptance criteria) OR stories/issues are no longer relevant or a priority.
+
+## Document information
+
+Last review/update: September 2020
+
+Additional related compliance controls: CM-4, CM-9, CM-11, SC-18


### PR DESCRIPTION
## Changes proposed in this pull request:

- https://github.com/cloud-gov/product/pull/1162 removed a lot of compliance information that fulfills our SSP SA-11 control, this PR restores that information
- This closes POAM 2020-V0070-SA-11
- Also cleaned up a lot of Markdown Lint errors regarding lists and bullets and blank line and blank spaces.

## security considerations

None: This restores already public information

