### PR TITLE
Link updates

### DIFF
--- a/PertinentLinks.md
+++ b/PertinentLinks.md
@@ -6,7 +6,7 @@ should be bookmarked and encouraged to check on a regular basis.
 
 #### General cloud.gov items
 
-- [ZenHub board (project tracking)][zenhub-story-board]
+- [Project board (project tracking)][https://github.com/orgs/cloud-gov/projects/2]
 - [cloud.gov Beta dashboard](https://dashboard-beta.fr.cloud.gov/) :lock:
 - [cloud.gov dashboard](https://dashboard.fr.cloud.gov/) :lock:
 - [cloud.gov Google Drive folder][cg-drive-folder] :lock:
@@ -46,5 +46,3 @@ should be bookmarked and encouraged to check on a regular basis.
 
 [github-cloud-gov-cg]: https://github.com/search?utf8=✓&q=org%3Acloud-gov+cg-&type=Repositories&ref=searchresults
 [github-cloud-gov-cg-deploy]: https://github.com/search?utf8=✓&q=org%3Acloud-gov+cg-deploy-&type=Repositories&ref=searchresults
-
-[zenhub-story-board]: https://app.zenhub.com/workspaces/cg-story-board-5d217e937454737fd4fcffc8/board


### PR DESCRIPTION
Removed references to Zenhub and included a link to our project board instead.

## Changes proposed in this pull request:
- Update links to our project board and remove Zenhub

## Security considerations
- None; updating links
