### PR TITLE
Add issue template for blog post ideas

### DIFF
--- a/.github/ISSUE_TEMPLATE/blog_post.md
+++ b/.github/ISSUE_TEMPLATE/blog_post.md
@@ -1,0 +1,32 @@
+---
+name: Blog Post
+title: 'Blog post: [title of your blog post]'
+about: INTERNAL ONLY propose a post for cloud.gov blog
+labels: communications
+assignees: ''
+
+---
+
+## Audience
+
+Tell us about the main target audience for this post with a user story that follows this format: As a *type of audience*, I want *to learn something*, so that *some benefit is had*. Check out the [blogging guide(https://handbook.tts.gsa.gov/blogging/#writing-a-great-post) for more info.
+
+## Goal of the post
+
+Your post should communicate one idea clearly. Briefly explain what your goal for writing this post is. 
+
+## Imagery ideas
+
+Will this post use imagery or a screen cast?
+
+## Outline
+
+Write an outline with three(3) or more bullet points.
+
+## Who needs to clear
+
+You'll need explicit approval from these people:
+
+- [ ] cloud.gov ED (or acting)
+- [ ] Biz unit
+- [ ] @karareinsel


### PR DESCRIPTION
## Changes proposed in this pull request:
- This PR adds a new issue template for blog post ideas.
- This will allow us to more consistently structure proposed blog post ideas and to assign and track work.

## security considerations
None.
