### PR TITLE
Add ADR folder and template

### DIFF
--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,11 @@
+# Architectural Decision Log
+
+This log lists the architectural decisions for cloud.gov. 
+
+- [ADR-0001](#) - Placeholder for ADR document here.
+- [ADR-0002](#) - Placeholder for ADR document here.
+
+For new ADRs, please use [template.md](template.md).
+
+More information on MADR is available at <https://adr.github.io/madr/>.
+General information about architectural decision records is available at <https://adr.github.io/>.

--- a/adr/template.md
+++ b/adr/template.md
@@ -1,0 +1,42 @@
+# *[short title of solved problem and solution]*
+
+**User Story:** *[ticket/issue-number]* <!-- optional -->
+
+*[context and problem statement]*
+*[decision drivers | forces]* <!-- optional -->
+
+## Considered Alternatives
+
+* *[alternative 1]*
+* *[alternative 2]*
+* *[alternative 3]*
+* *[...]* <!-- numbers of alternatives can vary -->
+
+## Decision Outcome
+
+* Chosen Alternative: *[alternative 1]*
+* *[justification. e.g., only alternative, which meets KO criterion decision driver | which resolves force force | ... | comes out best (see below)]*
+* *[consequences. e.g., negative impact on quality attribute, follow-up decisions required, ...]* <!-- optional -->
+
+## Pros and Cons of the Alternatives <!-- optional -->
+
+### *[alternative 1]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 2]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 3]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a new subfolder to hold ADR documents, and an ADR Decision log
- Add a template to use when creating new ADRs.

## security considerations
~N/A~ ADR pros and cons could provide a malicious actor with knowledge of system weaknesses, so we should be circumspect in our discussion, and possibly the hold back publication until _after_ we've implemented a solution. 