### PR TITLE
Offboard Becca

### DIFF
--- a/DeliveryProcess.md
+++ b/DeliveryProcess.md
@@ -8,7 +8,7 @@ Information about our prioritization process and [the Story Lifecycle](StoryLife
 We've structured our team into two teams.
 
 - Platform and compliance/security
-  - Ben Berry, Chris McGowan, Van Nguyen, Peter Burkholder, Andrew Burnes, Carlo Costino, Mark Headd, Rebecca Goodman
+  - Ben Berry, Chris McGowan, Van Nguyen, Peter Burkholder, Andrew Burnes, Carlo Costino, Mark Headd
   - Comm channels: #cg-platform
 
 - Customer and business


### PR DESCRIPTION
Removing Becca from the team squad list as a part of offboarding.

## Changes proposed in this pull request:
- Removes Becca from the squad list

## Security considerations:
- None; keeping our team information up-to-date