### PR TITLE
Remove Kara from team roster

### DIFF
--- a/DeliveryProcess.md
+++ b/DeliveryProcess.md
@@ -12,7 +12,7 @@ We've structured our team into two teams.
   - Comm channels: #cg-platform
 
 - Customer and business
-  - Kelley Confer, Kara Reinsel, Melanie Leopold, Gerald Sill
+  - Kelley Confer, Melanie Leopold, Gerald Sill
   - Comm channel: #cg-business
 
 


### PR DESCRIPTION
Kara has left the cloud.gov team.

## Changes proposed in this pull request:
- Remove Kara's name from the team roster.

## Security considerations:
- Helps us maintain our compliance requirements