### PR TITLE
Update the onboarding checklist to account for new training schedule

### DIFF
--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -105,7 +105,7 @@ Once you're added to these channels, you probably want to mute these channels un
 ## Platform-Ops-specific items
 
 You should already have admin rights on your machine as a part of its original setup.  If for whatever reason you don't,
-Please let `Buddy` know and they will help yuo request [local admin rights](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit) on your GFE Mac using [this justification](https://docs.google.com/document/d/1YGid3pTji5W_M9RuF1GDf614BVkLIRDmSrt1tDbej-o/edit).
+Please let `Buddy` know and they will help you request [local admin rights](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit) on your GFE Mac using [this justification](https://docs.google.com/document/d/1YGid3pTji5W_M9RuF1GDf614BVkLIRDmSrt1tDbej-o/edit).
 
 ### Account access
 

--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -48,7 +48,7 @@ These items help us fulfill security and compliance requirements (including for 
 
 #### Learn our policies and procedures
 
-For the thres trainings list at the top, `Buddy` will create a separate ticket to track the trainings once scheduling has been finished.  This will help consolidate trainings for multiple new members to the team and prevent them from blocking progress on this onboarding ticket.  Once the trainings are scheduled, they can be marked as complete here.
+For the three trainings list at the top, `Buddy` will create a separate ticket to track the trainings once scheduling has been finished.  This will help consolidate trainings for multiple new members to the team and prevent them from blocking progress on this onboarding ticket.  Once the trainings are scheduled, they can be marked as complete here.
 
 * [ ] Coordinate with your onboarding buddy to go through Contingency Planning training within 60 days (and annually after that). This will cover the following document, which you should also review before or after training:
   * [ ] Read the [Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).

--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -16,7 +16,7 @@ When someone new joins the cloud.gov team:
 
 ---
 
-In order to get `NewPerson` productively contributing to the cloud.gov team, `Buddy` should help `NewPerson` complete a prescribed set of tasks that will bring them up to speed.
+In order to get `NewPerson` productively contributing to the cloud.gov team, `Buddy` should help `NewPerson` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
 
 ## Directions
 
@@ -29,6 +29,9 @@ In order to get `NewPerson` productively contributing to the cloud.gov team, `Bu
 ### Required items for all team members
 
 These items help us fulfill security and compliance requirements (including for FedRAMP). If you get stuck, or if these requirements are confusing, ask for help from your buddy or in a cloud.gov channel.
+
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Be sure to introduce yourself and follow up with your onboarding buddy (they should have reached out to you at this point; if they haven't, please let the team know) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2). We use this board to organize, prioritize, and track our work.
 
 #### Pre-requisites
 
@@ -66,8 +69,6 @@ These items will help you come up to speed on cloud.gov and what it is, how it w
 should take the time to go through them, please do not try and tackle it all in one shot!  It can become overwhelming
 very quickly  `Buddy` will walk through this list with you at a high level with you to help manage the work.
 
-- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
-- [ ] Figure out who your onboarding buddy is (they should reach out to you) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2).We use this board to organize, prioritize, and track our work.
 - [ ] Read [the team onboarding document](https://github.com/cloud-gov/product/blob/master/Onboarding.md) for more context about cloud.gov.
 - [ ] Bookmark the [pertinent links listed here](https://github.com/cloud-gov/product/blob/master/PertinentLinks.md).
 - [ ] Read through [the Overview section of our site](https://cloud.gov/docs/overview/what-is-cloudgov/) for a broader understanding of cloud.gov, especially how we present it to potential customers and users.
@@ -142,27 +143,23 @@ Please let `Buddy` know and they will help you request [local admin rights](http
     - If you have none or one (e.g. sandbox) org, please reach out to your onboarding buddy, `Buddy`
 - [ ] Install the [Bosh CLI using their instructions for MacOS](https://bosh.io/docs/cli-v2-install/#using-homebrew-on-macos)
   - `brew install cloudfoundry/tap/bosh-cli`
-  - [ ] Verify the installation using
-    - `bosh -v`
+  - [ ] Verify the installation by running `bosh -v` in the command line
 - [ ] Install Terraform and other tools per [cg-provision](https://github.com/cloud-gov/cg-provision)
   - `brew install terraform`
   - `brew install awscli`
   - `brew install jq`
-  - [ ] Verify Terraform installed and is in your path
-    - Run `terraform` and helper text should display
-  - [ ] Verify AWS CLI installed and is in your path
-    - Run `aws` and helper text should display
+  - [ ] Verify Terraform installed and is in your path: run `terraform` and helper text should display
+  - [ ] Verify AWS CLI installed and is in your path: run `aws` and helper text should display
 - [ ] Install and configure `aws-vault` by [following our directions](https://cloud.gov/docs/ops/secrets/#install-aws-vault-for-aws-credentials-and-create-a-profile)
 - [ ] Install the Concourse `fly` CLI
   - Download the `fly` binary zip for MacOS from https://concourse-ci.org/
   - Extract the binary and move it to `/usr/local/bin/fly` so it's in your path
     - `cd ~/Downloads`
     - `mv fly /usr/local/bin/fly`
-  - [ ] Verify using `fly -h`
+  - [ ] Verify by running `fly -h` in your command line
     - This may fail due to app security policy on your mac rejecting apps from unidentified developers.
     - You can try the procedure [here](https://www.imore.com/how-open-apps-anywhere-macos-catalina-and-mojave) to change the app's security settings.
-- [ ] Install cloud.gov dev tools by cloning the [`cg-scripts` repo](https://github.com/cloud-gov/cg-scripts/)
-  - `git clone https://github.com/cloud-gov/cg-scripts.git`
+- [ ] Install cloud.gov dev tools by cloning the [`cg-scripts` repo](https://github.com/cloud-gov/cg-scripts/): run `git clone https://github.com/cloud-gov/cg-scripts.git` in your command line
 
 ### Figure out your first tasks
 

--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -9,35 +9,22 @@ When someone new joins the cloud.gov team:
   * Use of a private repo helps satisfy AC-2, that we have officially added a person to our team before further onboarding.
 2. View the raw source of this file.
 3. Copy the text before the checklists to the Description field of the card.
-3. Copy each applicable block of tasks into a its own new task list on the card, replacing "NewPerson" with the new person's name and  "Buddy" with the onboarding buddy's name.
+3. Copy each applicable block of tasks into a its own new task list on the card, replacing `NewPerson` with the new person's name and `Buddy` with the onboarding buddy's name.
 4. Submit the card.
 5. Assign the person who bravely volunteered to be the new person's Onboarding Buddy to the card.
 6. Put the issue into the _Doing_ column.
 
 ---
 
-In order to get NewPerson productively contributing to the cloud.gov team, Buddy should help NewPerson complete a prescribed set of tasks that will bring them up to speed.
+In order to get `NewPerson` productively contributing to the cloud.gov team, `Buddy` should help `NewPerson` complete a prescribed set of tasks that will bring them up to speed.
 
 ## Directions
 
-**NewPerson and Buddy:** Try to go through your checklists in order.
+**`NewPerson` and `Buddy`:** Try to go through your checklists in order.
 
-**Buddy:** If you can’t complete any of the items on your checklist personally, _you are responsible for ensuring that someone with the correct access completes that item_.
+**`Buddy`:** If you can’t complete any of the items on your checklist personally, _you are responsible for ensuring that someone with the correct access completes that item_.
 
-## New Person checklist
-
-### Getting to know cloud.gov
-
-- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
-- [ ] Figure out who your onboarding buddy is (they should reach out to you) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2).We use this board to organize, prioritize, and track our work.
-- [ ] Read [the team onboarding document](https://github.com/cloud-gov/product/blob/master/Onboarding.md) for more context about cloud.gov.
-- [ ] Bookmark the [pertinent links listed here](https://github.com/cloud-gov/product/blob/master/PertinentLinks.md).
-- [ ] Read through [the Overview section of our site](https://cloud.gov/docs/overview/what-is-cloudgov/) for a broader understanding of cloud.gov, especially how we present it to potential customers and users.
-- [ ] [Sign up for a cloud.gov sandbox](https://cloud.gov/sign-up/#get-trial-access-and-a-free-sandbox-space) and start experimenting to get familiar with the basics of the PaaS from a user's perspective.
-- [ ] Read the [Delivery Process document](https://github.com/cloud-gov/product/blob/master/StoryLifecycle.md) to learn about how we work.
-- [ ] Read our [service disruption guide](https://cloud.gov/docs/ops/service-disruption-guide/) to learn how we handle customer-facing service disruptions.
-- [ ] Add the [cloud.gov Google Drive folder](https://drive.google.com/drive/folders/0Bx6EvBXVDWwheUtVckVnOE1pRzA) to your Google Drive -- that's where we put cloud.gov docs. If you create or move a doc there, it'll get the right access permissions for team members to be able to view and edit it.
-- [ ] Subscribe to [the cloud.gov team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&amp;ctz=America/Los_Angeles) (click the + in the bottom right) so you know when assorted team meetings are happening in the various squads. Tip: When you plan Out of Office time, make a calendar event for that on the cloud.gov calendar so that your teammates know you'll be away
+## `NewPerson` checklist
 
 ### Required items for all team members
 
@@ -58,10 +45,12 @@ These items help us fulfill security and compliance requirements (including for 
 
 #### Learn our policies and procedures
 
-* [ ] Coordinate with your onboarding buddy to go through Contingency Planning training within 10 days (and annually after that). This will cover the following document, which you should also review before or after training:
-* [ ] Read the [Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).
+For the thres trainings list at the top, `Buddy` will create a separate ticket to track the trainings once scheduling has been finished.  This will help consolidate trainings for multiple new members to the team and prevent them from blocking progress on this onboarding ticket.  Once the trainings are scheduled, they can be marked as complete here.
+
+* [ ] Coordinate with your onboarding buddy to go through Contingency Planning training within 60 days (and annually after that). This will cover the following document, which you should also review before or after training:
+  * [ ] Read the [Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).
 * [ ] Coordinate with your onboarding buddy to go through [Incident Response Training](https://docs.google.com/presentation/d/1AZjQE8zBzMRWZIFUuJPkJLted1ykGtALrLPoPRx5Vls/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following document, which you should also review before or after training:
-* [ ] Read the [Incident Response Guide](https://cloud.gov/docs/ops/security-ir/).
+  * [ ] Read the [Incident Response Guide](https://cloud.gov/docs/ops/security-ir/).
 * [ ] Coordinate with your onboarding buddy to go through [nonpublic information training](https://docs.google.com/presentation/d/1uB4MlGCu8ZYUxjKVZKwicQ95MvLxaT4Mh93y6w79GPw/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following documents, which you should also review before or after training:
   * [ ] Review the [cloud.gov open source policy guidance about protecting sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).
   * [ ] Read our [sharing secret keys](https://cloud.gov/docs/ops/secrets/#sharing-secret-keys) policy.
@@ -71,11 +60,30 @@ These items help us fulfill security and compliance requirements (including for 
 * [ ] Read the [cloud.gov Security Policies and Procedures](https://github.com/cloud-gov/cg-compliance-docs). These documents explain the high-level policies and procedures we must comply with while running cloud.gov, sorted into security control "families" They explain that we follow GSA IT security policy, and they provide a summary of the procedures in our System Security Plan.
 * [ ] Review the System Security Plan (the latest version lives on [Google Drive](https://drive.google.com/drive/u/0/folders/0B6fPl5s12igNX3JwR2xFZVpmek0); look for "cloud.gov System Security Plan (SSP)" as a *.docx* file). Of particular note for onboarding: Section 9 (System Description) and Section 10 (System Environment)
 
+### Getting to know cloud.gov
+
+These items will help you come up to speed on cloud.gov and what it is, how it works, why it exists, etc.  While you
+should take the time to go through them, please do not try and tackle it all in one shot!  It can become overwhelming
+very quickly  `Buddy` will walk through this list with you at a high level with you to help manage the work.
+
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Figure out who your onboarding buddy is (they should reach out to you) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2).We use this board to organize, prioritize, and track our work.
+- [ ] Read [the team onboarding document](https://github.com/cloud-gov/product/blob/master/Onboarding.md) for more context about cloud.gov.
+- [ ] Bookmark the [pertinent links listed here](https://github.com/cloud-gov/product/blob/master/PertinentLinks.md).
+- [ ] Read through [the Overview section of our site](https://cloud.gov/docs/overview/what-is-cloudgov/) for a broader understanding of cloud.gov, especially how we present it to potential customers and users.
+- [ ] [Sign up for a cloud.gov sandbox](https://cloud.gov/sign-up/#get-trial-access-and-a-free-sandbox-space) using your GSA email address and start experimenting to get familiar with the basics of the PaaS from a user's perspective.
+  - This is also required in order to make you a platform admin once you've completed the Cybersecurity and Privacy training.
+- [ ] Read the [Delivery Process document](https://github.com/cloud-gov/product/blob/master/StoryLifecycle.md) to learn about how we work.
+- [ ] Read our [service disruption guide](https://cloud.gov/docs/ops/service-disruption-guide/) to learn how we handle customer-facing service disruptions.
+- [ ] Add the [cloud.gov Google Drive folder](https://drive.google.com/drive/folders/0Bx6EvBXVDWwheUtVckVnOE1pRzA) to your Google Drive -- that's where we put cloud.gov docs. If you create or move a doc there, it'll get the right access permissions for team members to be able to view and edit it.
+- [ ] Subscribe to [the cloud.gov team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&amp;ctz=America/Los_Angeles) (click the + in the bottom right) so you know when assorted team meetings are happening in the various squads. Tip: When you plan Out of Office time, make a calendar event for that on the cloud.gov calendar so that your teammates know you'll be away
+
 ### Slack channels
 
-Your onboarding buddy will add you to these Slack channels:
+Your onboarding buddy, `Buddy`, will add you to these Slack channels:
 
 - [ ] `#cloud-gov` - bots post announcements here
+- [ ] `#cg-billing` - private business development channel (if applicable)
 - [ ] `#cg-business` - business development (if applicable)
 - [ ] `#cg-compliance` - compliance-related information and discussion
 - [ ] `#cg-offtopic` - off-topic team sharing 
@@ -96,22 +104,24 @@ Once you're added to these channels, you probably want to mute these channels un
 
 ## Platform-Ops-specific items
 
-- Request [local admin rights](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit) on your GFE Mac using [this justification](https://docs.google.com/document/d/1YGid3pTji5W_M9RuF1GDf614BVkLIRDmSrt1tDbej-o/edit).
+You should already have admin rights on your machine as a part of its original setup.  If for whatever reason you don't,
+Please let `Buddy` know and they will help yuo request [local admin rights](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit) on your GFE Mac using [this justification](https://docs.google.com/document/d/1YGid3pTji5W_M9RuF1GDf614BVkLIRDmSrt1tDbej-o/edit).
 
 ### Account access
 
 *Note: These are all contingent on completing the GSA Mandatory Cyber Security and Privacy Training first. AWS user names should be identical across accounts so that permissions can be correctly managed by Terraform.*
 
-* [ ] [AWS Accounts](https://cloud.gov/docs/ops/aws-onboarding/) via the AWS web console (not Terraform) and provide one-time credentials.
-    * [ ] AWS GovCloud
-    * [ ] AWS East tied to GovCloud
-* [ ] Add their account name to the [audit input file](https://github.com/cloud-gov/cg-compliance/blob/master/audit/inputs.yml)
+* [ ] [AWS Accounts](https://cloud.gov/docs/ops/aws-onboarding/) via the AWS web console (not Terraform) and provide one-time credentials - these will be setup as read-only at the start, and once the 3 mandatory cloud.gov trainings are complete they will be switched to full admin accounts and added to the [audit input file](https://github.com/cloud-gov/cg-compliance/blob/master/audit/inputs.yml):
+  * [ ] AWS Commercial accounts
+  * [ ] AWS GovCloud accounts
 * [ ] Nessus Manager GUI
 * [ ] [Make them an admin](https://cloud.gov/docs/ops/managing-users/#managing-admins) of the platform.
 * [ ] Add them to the [`platform-ops`](https://github.com/orgs/cloud-gov/teams/platform-ops) team in GitHub.
 * [ ] Add them as an admin on the cg-django-uaa [docs](https://readthedocs.org/projects/cg-django-uaa/)
 * [ ] Add them to [the cloud.gov team Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!forum/cloud-gov) so they can participate in team-wide internal communication.
 * [ ] Business Unit Only - Add them to the [cloud.gov inquiries Google Group](https://groups.google.com/a/gsa.gov/forum/#!forum/cloud-gov-inquiries) so they can keep apprised of prospective new clients.
+
+`Buddy` will create a separate ticket tied to this one to track the AWS accounts being granted full admin access.
 
 ### Additional compliance setup/review
 
@@ -129,7 +139,7 @@ Once you're added to these channels, you probably want to mute these channels un
   - `cf login -a api.fr.cloud.gov --sso`
   - `cf orgs`
     - As a cloud.gov team member, you should have a very giant list of organizations
-    - If you have none or one (e.g. sandbox) org, contact your facilitator
+    - If you have none or one (e.g. sandbox) org, please reach out to your onboarding buddy, `Buddy`
 - [ ] Install the [Bosh CLI using their instructions for MacOS](https://bosh.io/docs/cli-v2-install/#using-homebrew-on-macos)
   - `brew install cloudfoundry/tap/bosh-cli`
   - [ ] Verify the installation using
@@ -156,7 +166,7 @@ Once you're added to these channels, you probably want to mute these channels un
 
 ### Figure out your first tasks
 
-Work with your onboarding buddy to determine a platform component to work on first.
+Please work with your onboarding buddy, `Buddy`, to determine a platform component to work on first.
 Once you've identified the component you're going to focus on, your onboarding buddy will introduce
 you to someone who can onboard you to that project in specific. For the next few sprints, work on features,
 bugs, and improvements on this component. Reach out to your onboarding buddy or anyone else on the team 
@@ -175,6 +185,9 @@ if you need any help. Here are some easily-separated pieces to consider:
 - shibboleth (Java, OIDC)
 
 ## Compliance Lead items
+
+These are items that are only necessary for someone stepping into the compliance lead role or a compliance lead support
+role, but you can still subscribe to the alerts and mailing lists if you're interested:
 
 - [ ] Subscribe to US-CERT alerts: https://us-cert.cisa.gov/mailing-lists-and-feeds
 - [ ] Subscribe to FedRAMP mailing lists: https://public.govdelivery.com/accounts/USGSA/subscriber/topics?qsp=USGSA_2224


### PR DESCRIPTION
We have recently discussed as a team that we will change our training schedule in order to remove the 10-day requirement for the contingency planning training.  In order to do this, we cannot grant full admin AWS access right away, so we are changing the onboarding checklist to account for this process.

This changeset also adjusts the order of some of the onboarding items and adds a bit more context for the different sections.

## Changes proposed in this pull request:
- Reorders the checklist to be more in line with the flow of work
- Adjusts the training schedule
- Adds more explicit references to `Buddy` and `NewPerson`
- Changes AWS account setup to be read-only at the start
- Explicitly calls out that `Buddy` will create new tickets to complete subsequent work (e.g., trainings, adjusting AWS account permissions) so as not to hold up the main onboarding ticket
- Adds more descriptions for each section
- Removes admin rights as an explicit task

## Security considerations:
- Updates our onboarding process to be a bit more streamlined and accounts for the controls we need to be mindful of when granting permissions to new team members vis-a-vis when they complete their trainings