### PR TITLE
Add GPG setup step

### DIFF
--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -131,6 +131,7 @@ Please let `Buddy` know and they will help you request [local admin rights](http
 
 * [ ] Install `caulking` git leak prevention by following the [README](https://github.com/cloud-gov/caulking/blob/master/README.md)
 * [ ] Verify `caulking` by running `make audit` and pasting a screenshot as a comment on this GitHub issue
+* [ ] Set GPG signing set up for GitHub (instructions [here](https://docs.google.com/document/d/11UDxvfkhncyLEs-NUCniw2u54j4uQBqsR2SBiLYPUZc/edit))
 
 ### Install a development environment for cloud.gov
 


### PR DESCRIPTION
Adds the GPG setup step from our other onboarding checklist template.

## Changes proposed in this pull request:
- Adds step for GPG setup

## Security considerations:
- Helps maintain our security posture by ensuring new team members have their machines configured correctly