### PR TITLE
Update issue templates for onboarding and offboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md
@@ -1,0 +1,164 @@
+---
+name: Onboard New cloud.gov Compliance Team Member
+title: Checklist for Onboarding a New Compliance Team Member
+about: This is the checklist and requirements for onboarding a new compliance team member to the cloud.gov team
+labels: ''
+assignees: ''
+
+---
+
+# New Compliance Team Member Onboarding Checklist
+
+**NOTE:  Do not create this issue until the System Owner has formally authorized and requested it.**
+
+In order to get `New Person` productively contributing to the cloud.gov team, `Buddy` should help `New Person` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
+
+## Instructions
+
+1. Try to go through the checklists in order.
+2. If `Buddy` can’t complete any of the items on their checklist personally, _they are responsible for ensuring that someone with the correct access completes that item_.
+
+## Onboarding Checklist
+
+### Required items for all team members
+
+These items help us fulfill security and compliance requirements (including for FedRAMP). If you get stuck, or if these requirements are confusing, ask for help from your buddy or in a cloud.gov channel.
+
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Be sure to introduce yourself and follow up with your onboarding buddy (they should have reached out to you at this point; if they haven't, please let the team know) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2). We use this board to organize, prioritize, and track our work.
+
+#### Pre-requisites
+
+- [ ] Complete [GSA OLU](https://gsaolu.gsa.gov/) GSA Mandatory Cyber Security and Privacy Training, including accepting the GSA IT Rules of Behavior, which is required before we can give you access to any cloud.gov systems. If you joined GSA more than two months ago, you've already completed this task and can just check the box.
+
+#### Fulfill security and compliance requirements (including for FedRAMP) - Completed by onboarding buddy
+
+- [ ] Make sure they're in [the list of people working on the project](https://docs.google.com/spreadsheets/d/1mW3tphZ98ExmMxLHPogSpTq8DzYr5Oh8_SHnOTvjRWM/edit#gid=0).
+- [ ] Add their name, whether they're Cloud Ops (Platform), and the date they joined the team to the [training tracker](https://docs.google.com/spreadsheets/d/1hqU6cNeEB293OT0j3OvbdAFRkrf2zDOrPVxGfnr4sSw/edit#gid=0). Copy the formulas for the due dates from an existing row (grab the "corner" of the cells and pull down).
+- [ ] As they complete training, fill out their completion dates in the [training tracker](https://docs.google.com/spreadsheets/d/1hqU6cNeEB293OT0j3OvbdAFRkrf2zDOrPVxGfnr4sSw/edit#gid=0).
+- [ ] Add them to the @cloud-gov-team [in Slack’s Team Directory](https://get.slack.help/hc/en-us/articles/212906697-User-Groups#edit-a-user-group).
+- [ ] Review the recurring cloud.gov meetings that are relevant for them in [the team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&amp;ctz=America/Los_Angeles) (they will get access to this when added to the cloud.gov Team Google Group).
+- [ ] Add them to the [`cloud-gov`](https://github.com/orgs/cloud-gov/people) organization in GitHub, and the [`cloud-gov-team`](https://github.com/orgs/cloud-gov/teams/cloud-gov-team) team.
+
+#### Learn our policies and procedures
+
+For the three trainings list at the top, your onboarding buddy will create a separate ticket to track the trainings once scheduling has been finished.  This will help consolidate trainings for multiple new members to the team and prevent them from blocking progress on this onboarding ticket.  Once the trainings are scheduled, they can be marked as complete here.
+
+* [ ] Coordinate with your onboarding buddy to go through Contingency Planning training within 60 days (and annually after that). This will cover the following document, which you should also review before or after training:
+  * [ ] Read the [Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).
+* [ ] Coordinate with your onboarding buddy to go through [Incident Response Training](https://docs.google.com/presentation/d/1AZjQE8zBzMRWZIFUuJPkJLted1ykGtALrLPoPRx5Vls/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following document, which you should also review before or after training:
+  * [ ] Read the [Incident Response Guide](https://cloud.gov/docs/ops/security-ir/).
+* [ ] Coordinate with your onboarding buddy to go through [nonpublic information training](https://docs.google.com/presentation/d/1uB4MlGCu8ZYUxjKVZKwicQ95MvLxaT4Mh93y6w79GPw/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following documents, which you should also review before or after training:
+  * [ ] Review the [cloud.gov open source policy guidance about protecting sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).
+  * [ ] Read our [sharing secret keys](https://cloud.gov/docs/ops/secrets/#sharing-secret-keys) policy.
+  * [ ] Review the [TTS requirements for password management](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/password-requirements/).
+* [ ] Read the [Continuous Monitoring Strategy](https://cloud.gov/docs/ops/continuous-monitoring/), particularly the [cloud.gov team responsibilities](https://cloud.gov/docs/ops/continuous-monitoring/#cloud-gov-team).
+* [ ] Read the [Configuration Management Plan](https://cloud.gov/docs/ops/configuration-management/).
+* [ ] Read the [cloud.gov Security Policies and Procedures](https://github.com/cloud-gov/cg-compliance-docs). These documents explain the high-level policies and procedures we must comply with while running cloud.gov, sorted into security control "families" They explain that we follow GSA IT security policy, and they provide a summary of the procedures in our System Security Plan.
+* [ ] Review the System Security Plan (the latest version lives on [Google Drive](https://drive.google.com/drive/u/0/folders/0B6fPl5s12igNX3JwR2xFZVpmek0); look for "cloud.gov System Security Plan (SSP)" as a *.docx* file). Of particular note for onboarding: Section 9 (System Description) and Section 10 (System Environment)
+
+### Getting to know cloud.gov
+
+These items will help you come up to speed on cloud.gov and what it is, how it works, why it exists, etc.  While you
+should take the time to go through them, please do not try and tackle it all in one shot!  It can become overwhelming
+very quickly, so your onboarding buddy will walk through this list with you at a high level with you to help manage the work.
+
+- [ ] Read [the team onboarding document](https://github.com/cloud-gov/product/blob/master/Onboarding.md) for more context about cloud.gov.
+- [ ] Bookmark the [pertinent links listed here](https://github.com/cloud-gov/product/blob/master/PertinentLinks.md).
+- [ ] Read through [the Overview section of our site](https://cloud.gov/docs/overview/what-is-cloudgov/) for a broader understanding of cloud.gov, especially how we present it to potential customers and users.
+- [ ] [Sign up for a cloud.gov sandbox](https://cloud.gov/sign-up/#get-trial-access-and-a-free-sandbox-space) using your GSA email address and start experimenting to get familiar with the basics of the PaaS from a user's perspective.
+  - This is also required in order to make you a platform admin once you've completed the Cybersecurity and Privacy training.
+- [ ] Read the [Delivery Process document](https://github.com/cloud-gov/product/blob/master/StoryLifecycle.md) to learn about how we work.
+- [ ] Read our [service disruption guide](https://cloud.gov/docs/ops/service-disruption-guide/) to learn how we handle customer-facing service disruptions.
+- [ ] Add the [cloud.gov Google Drive folder](https://drive.google.com/drive/folders/0Bx6EvBXVDWwheUtVckVnOE1pRzA) to your Google Drive -- that's where we put cloud.gov docs. If you create or move a doc there, it'll get the right access permissions for team members to be able to view and edit it.
+- [ ] Subscribe to [the cloud.gov team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&amp;ctz=America/Los_Angeles) (click the + in the bottom right) so you know when assorted team meetings are happening in the various squads. Tip: When you plan Out of Office time, make a calendar event for that on the cloud.gov calendar so that your teammates know you'll be away
+
+### Slack channels
+
+Your onboarding buddy will add you to these Slack channels:
+
+- [ ] `#cloud-gov` - bots post announcements here
+- [ ] `#cg-billing` - private business development channel (if applicable)
+- [ ] `#cg-business` - business development (if applicable)
+- [ ] `#cg-compliance` - compliance-related information and discussion
+- [ ] `#cg-offtopic` - off-topic team sharing
+- [ ] `#cg-platform` - platform operations
+- [ ] `#cg-platform-news` - bots post platform alerts
+- [ ] `#cg-general` - program-level information and discusion
+- [ ] `#cg-support` - support requests and assistance within TTS
+- [ ] `#cg-incidents` - private channel for incident response
+- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
+- [ ] `#cg-priv-all` - private channel for in-team discussion
+- [ ] `#cg-priv-gov` (Federal employees only) - may contain discussion of contracting-related or other private, federal-employee-only comms
+
+Once you're added to these channels, you probably want to mute these channels until you're on support rotation:
+
+- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
+- [ ] `#cg-support` - support requests and assistance within TTS
+- [ ] `#cg-platform-news` - platform alerts
+
+## Compliance-role specific items
+
+You should already have admin rights on your machine as a part of its original setup.  If for whatever reason you don't,
+Please let your onboarding buddy know and they will help you request [local admin rights](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit) on your GFE Mac using [this justification](https://docs.google.com/document/d/1YGid3pTji5W_M9RuF1GDf614BVkLIRDmSrt1tDbej-o/edit).
+
+### Cloud Operations account management
+
+*Note: These are all contingent on completing the GSA Mandatory Cyber Security and Privacy Training first. AWS user names should be identical across accounts so that permissions can be correctly managed by Terraform.*
+
+* [ ] Create [AWS Accounts](https://cloud.gov/docs/ops/aws-onboarding/) via the AWS web console (not Terraform) and provide one-time credentials - these will be setup with read-only/auditor permissions, and once the 3 mandatory cloud.gov trainings are complete they will be added to the [audit input file](https://github.com/cloud-gov/cg-compliance/blob/master/audit/inputs.yml):
+  * [ ] AWS Commercial accounts
+  * [ ] AWS GovCloud accounts
+* [ ] Add them to Nessus Manager via the GUI
+* [ ] [Make them an admin](https://cloud.gov/docs/ops/managing-users/#managing-admins) of the platform.
+* [ ] Add them to the [`platform-ops`](https://github.com/orgs/cloud-gov/teams/platform-ops) team in GitHub.
+* [ ] Add them as an admin on the cg-django-uaa [docs](https://readthedocs.org/projects/cg-django-uaa/)
+* [ ] Add them to [the cloud.gov team Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!forum/cloud-gov) so they can participate in team-wide internal communication.
+* [ ] Add them to [our dockerhub org](https://hub.docker.com/orgs/cloudgov) and ensure we're not over our license count
+* [ ] Business Unit Only - Add them to the [cloud.gov inquiries Google Group](https://groups.google.com/a/gsa.gov/forum/#!forum/cloud-gov-inquiries) so they can keep apprised of prospective new clients.
+
+Your onboarding buddy will create a separate ticket tied to this one to track the AWS accounts being granted full admin access.
+
+### Additional compliance setup/review
+
+* [ ] Install `caulking` git leak prevention by following the [README](https://github.com/cloud-gov/caulking/blob/master/README.md)
+* [ ] Verify `caulking` by running `make audit` and pasting a screenshot as a comment on this GitHub issue
+* [ ] Set GPG signing set up for GitHub (instructions [here](https://docs.google.com/document/d/11UDxvfkhncyLEs-NUCniw2u54j4uQBqsR2SBiLYPUZc/edit))
+
+### Install a development environment for cloud.gov
+
+- [ ] Install [Homebrew (`brew`)](https://brew.sh/)
+- [ ] Install [CloudFoundry for mac per their docs](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#pkg-mac):
+  - `brew tap cloudfoundry/tap`
+  - `brew install cf-cli@7`
+  - `brew install openssl`
+- [ ] Verify CloudFoundry Installation via the CLI (once an existing cloud.gov teammate has [made your cloud.gov admin account](https://cloud.gov/docs/ops/managing-users/#creating-admins))
+  - `cf login -a api.fr.cloud.gov --sso`
+  - `cf orgs`
+    - As a cloud.gov compliance team member, you should have a very giant list of organizations
+    - If you have none or one (e.g. sandbox) org, please reach out to your onboarding buddy
+- [ ] Install the [Bosh CLI using their instructions for MacOS](https://bosh.io/docs/cli-v2-install/#using-homebrew-on-macos)
+  - `brew install cloudfoundry/tap/bosh-cli`
+  - [ ] Verify the installation by running `bosh -v` in the command line
+- [ ] Install Terraform and other tools per [cg-provision](https://github.com/cloud-gov/cg-provision)
+  - `brew install terraform`
+  - `brew install awscli`
+  - `brew install jq`
+  - [ ] Verify Terraform installed and is in your path: run `terraform` and helper text should display
+  - [ ] Verify AWS CLI installed and is in your path: run `aws` and helper text should display
+- [ ] Install and configure `aws-vault` by [following our directions](https://cloud.gov/docs/ops/secrets/#install-aws-vault-for-aws-credentials-and-create-a-profile)
+- [ ] Install the Concourse `fly` CLI
+  - Download the `fly` binary zip for MacOS from https://concourse-ci.org/
+  - Extract the binary and move it to `/usr/local/bin/fly` so it's in your path
+    - `cd ~/Downloads`
+    - `mv fly /usr/local/bin/fly`
+  - [ ] Verify by running `fly -h` in your command line
+    - This may fail due to app security policy on your mac rejecting apps from unidentified developers.
+    - You can try the procedure [here](https://www.imore.com/how-open-apps-anywhere-macos-catalina-and-mojave) to change the app's security settings.
+- [ ] Install cloud.gov dev tools by cloning the [`cg-scripts` repo](https://github.com/cloud-gov/cg-scripts/): run `git clone https://github.com/cloud-gov/cg-scripts.git` in your command line
+
+These are items that are only necessary for someone stepping into a compliance role, but you can still subscribe to the alerts and mailing lists if you're interested:
+
+- [ ] Subscribe to US-CERT alerts: https://us-cert.cisa.gov/mailing-lists-and-feeds
+- [ ] Subscribe to FedRAMP mailing lists: https://public.govdelivery.com/accounts/USGSA/subscriber/topics?qsp=USGSA_2224
+- [ ] Read Compliance Lead documents at root of the [Google Drive Security and Compliance](https://drive.google.com/drive/u/0/folders/1_vAXZsdVFYssR1DRCaavBCoDE_uxQCI5) folder

--- a/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md
@@ -1,0 +1,98 @@
+---
+name: Onboard New cloud.gov Team Member
+title: Checklist for Onboarding a New Team Member
+about: This is the checklist and requirements for onboarding a new team member to the cloud.gov team
+labels: ''
+assignees: ''
+
+---
+
+# New Team Member Onboarding Checklist
+
+**NOTE:  Do not create this issue until the System Owner has formally authorized and requested it.**
+
+In order to get `New Person` productively contributing to the cloud.gov team, `Buddy` should help `New Person` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
+
+## Instructions
+
+1. Try to go through the checklists in order.
+2. If `Buddy` can’t complete any of the items on their checklist personally, _they are responsible for ensuring that someone with the correct access completes that item_.
+
+## Onboarding Checklist
+
+### Required items for all team members
+
+These items help us fulfill security and compliance requirements (including for FedRAMP). If you get stuck, or if these requirements are confusing, ask for help from your buddy or in a cloud.gov channel.
+
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Be sure to introduce yourself and follow up with your onboarding buddy (they should have reached out to you at this point; if they haven't, please let the team know) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2). We use this board to organize, prioritize, and track our work.
+
+#### Pre-requisites
+
+- [ ] Complete [GSA OLU](https://gsaolu.gsa.gov/) GSA Mandatory Cyber Security and Privacy Training, including accepting the GSA IT Rules of Behavior, which is required before we can give you access to any cloud.gov systems. If you joined GSA more than two months ago, you've already completed this task and can just check the box.
+
+#### Fulfill security and compliance requirements (including for FedRAMP) - Completed by onboarding buddy
+
+- [ ] Make sure they're in [the list of people working on the project](https://docs.google.com/spreadsheets/d/1mW3tphZ98ExmMxLHPogSpTq8DzYr5Oh8_SHnOTvjRWM/edit#gid=0).
+- [ ] Add their name, whether they're Cloud Ops (Platform), and the date they joined the team to the [training tracker](https://docs.google.com/spreadsheets/d/1hqU6cNeEB293OT0j3OvbdAFRkrf2zDOrPVxGfnr4sSw/edit#gid=0). Copy the formulas for the due dates from an existing row (grab the "corner" of the cells and pull down).
+- [ ] As they complete training, fill out their completion dates in the [training tracker](https://docs.google.com/spreadsheets/d/1hqU6cNeEB293OT0j3OvbdAFRkrf2zDOrPVxGfnr4sSw/edit#gid=0).
+- [ ] Add them to the @cloud-gov-team [in Slack’s Team Directory](https://get.slack.help/hc/en-us/articles/212906697-User-Groups#edit-a-user-group).
+- [ ] Review the recurring cloud.gov meetings that are relevant for them in [the team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&amp;ctz=America/Los_Angeles) (they will get access to this when added to the cloud.gov Team Google Group).
+- [ ] Add them to the [`cloud-gov`](https://github.com/orgs/cloud-gov/people) organization in GitHub, and the [`cloud-gov-team`](https://github.com/orgs/cloud-gov/teams/cloud-gov-team) team.
+
+#### Learn our policies and procedures
+
+For the three trainings list at the top, your onboarding buddy will create a separate ticket to track the trainings once scheduling has been finished.  This will help consolidate trainings for multiple new members to the team and prevent them from blocking progress on this onboarding ticket.  Once the trainings are scheduled, they can be marked as complete here.
+
+* [ ] Coordinate with your onboarding buddy to go through Contingency Planning training within 60 days (and annually after that). This will cover the following document, which you should also review before or after training:
+  * [ ] Read the [Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).
+* [ ] Coordinate with your onboarding buddy to go through [Incident Response Training](https://docs.google.com/presentation/d/1AZjQE8zBzMRWZIFUuJPkJLted1ykGtALrLPoPRx5Vls/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following document, which you should also review before or after training:
+  * [ ] Read the [Incident Response Guide](https://cloud.gov/docs/ops/security-ir/).
+* [ ] Coordinate with your onboarding buddy to go through [nonpublic information training](https://docs.google.com/presentation/d/1uB4MlGCu8ZYUxjKVZKwicQ95MvLxaT4Mh93y6w79GPw/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following documents, which you should also review before or after training:
+  * [ ] Review the [cloud.gov open source policy guidance about protecting sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).
+  * [ ] Read our [sharing secret keys](https://cloud.gov/docs/ops/secrets/#sharing-secret-keys) policy.
+  * [ ] Review the [TTS requirements for password management](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/password-requirements/).
+* [ ] Read the [Continuous Monitoring Strategy](https://cloud.gov/docs/ops/continuous-monitoring/), particularly the [cloud.gov team responsibilities](https://cloud.gov/docs/ops/continuous-monitoring/#cloud-gov-team).
+* [ ] Read the [Configuration Management Plan](https://cloud.gov/docs/ops/configuration-management/).
+* [ ] Read the [cloud.gov Security Policies and Procedures](https://github.com/cloud-gov/cg-compliance-docs). These documents explain the high-level policies and procedures we must comply with while running cloud.gov, sorted into security control "families" They explain that we follow GSA IT security policy, and they provide a summary of the procedures in our System Security Plan.
+* [ ] Review the System Security Plan (the latest version lives on [Google Drive](https://drive.google.com/drive/u/0/folders/0B6fPl5s12igNX3JwR2xFZVpmek0); look for "cloud.gov System Security Plan (SSP)" as a *.docx* file). Of particular note for onboarding: Section 9 (System Description) and Section 10 (System Environment)
+
+### Getting to know cloud.gov
+
+These items will help you come up to speed on cloud.gov and what it is, how it works, why it exists, etc.  While you
+should take the time to go through them, please do not try and tackle it all in one shot!  It can become overwhelming
+very quickly, so your onboarding buddy will walk through this list with you at a high level with you to help manage the work.
+
+- [ ] Read [the team onboarding document](https://github.com/cloud-gov/product/blob/master/Onboarding.md) for more context about cloud.gov.
+- [ ] Bookmark the [pertinent links listed here](https://github.com/cloud-gov/product/blob/master/PertinentLinks.md).
+- [ ] Read through [the Overview section of our site](https://cloud.gov/docs/overview/what-is-cloudgov/) for a broader understanding of cloud.gov, especially how we present it to potential customers and users.
+- [ ] [Sign up for a cloud.gov sandbox](https://cloud.gov/sign-up/#get-trial-access-and-a-free-sandbox-space) using your GSA email address and start experimenting to get familiar with the basics of the PaaS from a user's perspective.
+  - This is also required in order to make you a platform admin once you've completed the Cybersecurity and Privacy training.
+- [ ] Read the [Delivery Process document](https://github.com/cloud-gov/product/blob/master/StoryLifecycle.md) to learn about how we work.
+- [ ] Read our [service disruption guide](https://cloud.gov/docs/ops/service-disruption-guide/) to learn how we handle customer-facing service disruptions.
+- [ ] Add the [cloud.gov Google Drive folder](https://drive.google.com/drive/folders/0Bx6EvBXVDWwheUtVckVnOE1pRzA) to your Google Drive -- that's where we put cloud.gov docs. If you create or move a doc there, it'll get the right access permissions for team members to be able to view and edit it.
+- [ ] Subscribe to [the cloud.gov team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&amp;ctz=America/Los_Angeles) (click the + in the bottom right) so you know when assorted team meetings are happening in the various squads. Tip: When you plan Out of Office time, make a calendar event for that on the cloud.gov calendar so that your teammates know you'll be away
+
+### Slack channels
+
+Your onboarding buddy will add you to these Slack channels:
+
+- [ ] `#cloud-gov` - bots post announcements here
+- [ ] `#cg-billing` - private business development channel (if applicable)
+- [ ] `#cg-business` - business development (if applicable)
+- [ ] `#cg-compliance` - compliance-related information and discussion
+- [ ] `#cg-offtopic` - off-topic team sharing
+- [ ] `#cg-platform` - platform operations
+- [ ] `#cg-platform-news` - bots post platform alerts
+- [ ] `#cg-general` - program-level information and discusion
+- [ ] `#cg-support` - support requests and assistance within TTS
+- [ ] `#cg-incidents` - private channel for incident response
+- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
+- [ ] `#cg-priv-all` - private channel for in-team discussion
+- [ ] `#cg-priv-gov` (Federal employees only) - may contain discussion of contracting-related or other private, federal-employee-only comms
+
+Once you're added to these channels, you probably want to mute these channels until you're on support rotation:
+
+- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
+- [ ] `#cg-support` - support requests and assistance within TTS
+- [ ] `#cg-platform-news` - platform alerts

--- a/.github/ISSUE_TEMPLATE/pages-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/pages-team-member-onboarding.md
@@ -1,0 +1,32 @@
+ #### User Story
+
+Onboard <Person>
+
+#### Background (Optional)
+
+https://docs.google.com/document/d/1tS-9hLb2yHtp500N3obmu0X70XpIMATuPlov2_vDVS0/edit
+
+#### Acceptance Criteria
+- [ ] Share README
+- [ ] Grant appropriate access to Federalist backend in cloud.gov
+- [ ] Add to federalist-admins
+- [ ] Add to federalist-admins in federalist-users org.
+- [ ] Add to cloud-gov-team in cloud-gov org.
+- [ ] Add to pages-ops in cloud-gov org.
+- [ ] Make owner in the federalist-users org.
+- [ ] Add to #federalist- channels in Slack as needed, and add to @federalist-operators Slack user group
+- [ ] Add to daily standup, retro, and sprint planning
+- [ ] Ensure user has Federalist Github project and brief on its use
+- [ ] Ensure user has GPG signing set up for GitHub: https://docs.google.com/document/d/11UDxvfkhncyLEs-NUCniw2u54j4uQBqsR2SBiLYPUZc/edit
+- [ ] Add to New Relic
+- [ ] Add to federalist-support, federalist-alerts, and federalist-inquiries Google Groups as needed
+- [ ] Add them as an agent to https://federalist-support.zendesk.com/agent
+- [ ] add to Federalist search.gov account
+- [ ] Add new user as developer to the gsa-18f-federalist cloud.gov cloudfoundry organization
+- [ ] Add to statuspage.io account
+- [ ] Have a cloud.gov operator add to the “pages.admin” group in the cloud.gov UAA by using the make-pages-admin.sh script
+- [ ] Have a cloud.gov operator add to the “concourse.pages” team in the cloud.gov OpsUAA by using the make-pages-ops-admin.sh script so they can access Concourse CI
+- [ ] Add to Docker Hub
+- [ ] Add to AWS (Production GovCloud only)
+- [ ] Add to `FederalistLocal` Github org and `federalist-local-admins` team
+- [ ] Add to cloud.gov calendar

--- a/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md
@@ -81,7 +81,7 @@ Your onboarding buddy will add you to these Slack channels:
 - [ ] `#cg-billing` - private business development channel (if applicable)
 - [ ] `#cg-business` - business development (if applicable)
 - [ ] `#cg-compliance` - compliance-related information and discussion
-- [ ] `#cg-offtopic` - off-topic team sharing 
+- [ ] `#cg-offtopic` - off-topic team sharing
 - [ ] `#cg-platform` - platform operations
 - [ ] `#cg-platform-news` - bots post platform alerts
 - [ ] `#cg-general` - program-level information and discusion
@@ -136,7 +136,7 @@ Your onboarding buddy will create a separate ticket tied to this one to track th
   - `cf login -a api.fr.cloud.gov --sso`
   - `cf orgs`
     - As a cloud.gov team member, you should have a very giant list of organizations
-    - If you have none or one (e.g. sandbox) org, please reach out to your onboarding buddy, `Buddy`
+    - If you have none or one (e.g. sandbox) org, please reach out to your onboarding buddy
 - [ ] Install the [Bosh CLI using their instructions for MacOS](https://bosh.io/docs/cli-v2-install/#using-homebrew-on-macos)
   - `brew install cloudfoundry/tap/bosh-cli`
   - [ ] Verify the installation by running `bosh -v` in the command line

--- a/.github/ISSUE_TEMPLATE/so-authorize-offboarding.md
+++ b/.github/ISSUE_TEMPLATE/so-authorize-offboarding.md
@@ -1,0 +1,30 @@
+---
+name: System Owner Authorize Offboarding
+title: System Owner Authorization for Offboarding an Existing Team Member
+about: INTERNAL ONLY - CAN ONLY BE CREATED BY THE SYSTEM OWNER
+labels: compliance
+assignees: ''
+
+---
+
+# Formal Authorization Request to Offboard an existing cloud.gov Team Member
+
+**NOTE: Only the System Owner can create these issues.**
+
+If anyone else creates this type of issue, it will be considered invalid and closed with no further action taken.
+
+## Instructions
+
+As the System Owner, use this issue template to create a new issue to formally authorize the offboarding of an existing cloud.gov team member.  Please fill in the `keywords` with the appropriate information so that the follow up offboarding ticket can be created correctly.
+
+Once you create the issue, delete everything from this line and above when you're finished editing so the issue is complete and ready to be acted upon.  It should contain just the message below, with the correct information filled in for the `keywords`.
+
+---
+
+@cloud-gov/platform-ops:
+
+Please create an offboarding ticket for `Existing Person`.  This must be completed no later than `Offboarding Date`.  Thank you.
+
+Sincerely,
+
+`System Owner Name`, System Owner

--- a/.github/ISSUE_TEMPLATE/so-authorize-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/so-authorize-onboarding.md
@@ -1,0 +1,44 @@
+---
+name: System Owner Authorize Onboarding
+title: System Owner Authorization for Onboarding a New Team Member
+about: INTERNAL ONLY - CAN ONLY BE CREATED BY THE SYSTEM OWNER
+labels: compliance
+assignees: ''
+
+---
+
+# Formal Authorization Request to Onboard a new cloud.gov Team Member
+
+**NOTE: Only the System Owner can create these issues.**
+
+If anyone else creates this type of issue, it will be considered invalid and closed with no further action taken.
+
+## Instructions
+
+As the System Owner, use this issue template to create a new issue to formally authorize the onboarding of a new cloud.gov team member.  Please fill in the `keywords` with the appropriate information so that the follow up onboarding ticket can be created correctly.
+
+These are the roles we can onboard folks into currently (please refer to the System Security Plan for the full list):
+
+- Cloud Compliance
+- Cloud Development / Customer / Design
+- Cloud Operations
+- System Owner
+
+These are the teams we can currently have:
+
+- Business Unit
+- Platform Operators
+- Compliance
+- Support
+
+Once you create the issue, delete everything from this line and above when you're finished editing so the issue is complete and ready to be acted upon.  It should contain just the message below, with the correct information filled in for the `keywords`.
+
+---
+
+@cloud-gov/platform-ops:
+
+Please create a `Role` onboarding ticket for `New Person` as a new member of the `Team` team.  Thank you.
+
+Sincerely,
+
+`System Owner Name`, System Owner

--- a/.github/ISSUE_TEMPLATE/so-authorize-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/so-authorize-onboarding.md
@@ -22,13 +22,15 @@ These are the roles we can onboard folks into currently (please refer to the Sys
 - Cloud Compliance
 - Cloud Development / Customer / Design
 - Cloud Operations
+- Pages Operator
 - System Owner
 
-These are the teams we can currently have:
+These are the teams we currently have:
 
 - Business Unit
-- Platform Operators
 - Compliance
+- Pages
+- Platform Operators
 - Support
 
 Once you create the issue, delete everything from this line and above when you're finished editing so the issue is complete and ready to be acted upon.  It should contain just the message below, with the correct information filled in for the `keywords`.
@@ -37,7 +39,7 @@ Once you create the issue, delete everything from this line and above when you'r
 
 @cloud-gov/platform-ops:
 
-Please create a `Role` onboarding ticket for `New Person` as a new member of the `Team` team.  Thank you.
+Please create a `Role` onboarding ticket for `New Person` as a new member of the `Team` team within cloud.gov.  Thank you.
 
 Sincerely,
 

--- a/.github/ISSUE_TEMPLATE/support-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/support-member-onboarding.md
@@ -1,0 +1,123 @@
+---
+name: Onboard New cloud.gov Support Team Member
+title: Checklist for Onboarding a cloud.gov Support Team Member
+about: This is the checklist and requirements for onboarding a new support team member to the cloud.gov team
+labels: ''
+assignees: ''
+
+---
+
+# New Support Team Member Onboarding Checklist
+
+**NOTE:  Do not create this issue until the System Owner has formally authorized and requested it.**
+
+In order to get `New Person` productively contributing to the cloud.gov team, `Buddy` should help `New Person` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
+
+## Instructions
+
+1. Try to go through the checklists in order.
+2. If `Buddy` can’t complete any of the items on their checklist personally, _they are responsible for ensuring that someone with the correct access completes that item_.
+
+## Onboarding Checklist
+
+### Required items for all team members
+
+These items help us fulfill security and compliance requirements (including for FedRAMP). If you get stuck, or if these requirements are confusing, ask for help from your buddy or in a cloud.gov channel.
+
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Be sure to introduce yourself and follow up with your onboarding buddy (they should have reached out to you at this point; if they haven't, please let the team know) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2). We use this board to organize, prioritize, and track our work.
+
+#### Pre-requisites
+
+- [ ] Complete [GSA OLU](https://gsaolu.gsa.gov/) GSA Mandatory Cyber Security and Privacy Training, including accepting the GSA IT Rules of Behavior, which is required before we can give you access to any cloud.gov systems. If you joined GSA more than two months ago, you've already completed this task and can just check the box.
+
+#### Fulfill security and compliance requirements (including for FedRAMP) - Completed by onboarding buddy
+
+- [ ] Make sure they're in [the list of people working on the project](https://docs.google.com/spreadsheets/d/1mW3tphZ98ExmMxLHPogSpTq8DzYr5Oh8_SHnOTvjRWM/edit#gid=0).
+- [ ] Add their name, whether they're Cloud Ops (Platform), and the date they joined the team to the [training tracker](https://docs.google.com/spreadsheets/d/1hqU6cNeEB293OT0j3OvbdAFRkrf2zDOrPVxGfnr4sSw/edit#gid=0). Copy the formulas for the due dates from an existing row (grab the "corner" of the cells and pull down).
+- [ ] As they complete training, fill out their completion dates in the [training tracker](https://docs.google.com/spreadsheets/d/1hqU6cNeEB293OT0j3OvbdAFRkrf2zDOrPVxGfnr4sSw/edit#gid=0).
+- [ ] Add them to the @cloud-gov-team [in Slack’s Team Directory](https://get.slack.help/hc/en-us/articles/212906697-User-Groups#edit-a-user-group).
+- [ ] Review the recurring cloud.gov meetings that are relevant for them in [the team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&amp;ctz=America/Los_Angeles) (they will get access to this when added to the cloud.gov Team Google Group).
+- [ ] Add them to the [`cloud-gov`](https://github.com/orgs/cloud-gov/people) organization in GitHub, and the [`cloud-gov-team`](https://github.com/orgs/cloud-gov/teams/cloud-gov-team) team.
+
+#### Learn our policies and procedures
+
+For the three trainings list at the top, your onboarding buddy will create a separate ticket to track the trainings once scheduling has been finished.  This will help consolidate trainings for multiple new members to the team and prevent them from blocking progress on this onboarding ticket.  Once the trainings are scheduled, they can be marked as complete here.
+
+* [ ] Coordinate with your onboarding buddy to go through Contingency Planning training within 60 days (and annually after that). This will cover the following document, which you should also review before or after training:
+  * [ ] Read the [Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).
+* [ ] Coordinate with your onboarding buddy to go through [Incident Response Training](https://docs.google.com/presentation/d/1AZjQE8zBzMRWZIFUuJPkJLted1ykGtALrLPoPRx5Vls/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following document, which you should also review before or after training:
+  * [ ] Read the [Incident Response Guide](https://cloud.gov/docs/ops/security-ir/).
+* [ ] Coordinate with your onboarding buddy to go through [nonpublic information training](https://docs.google.com/presentation/d/1uB4MlGCu8ZYUxjKVZKwicQ95MvLxaT4Mh93y6w79GPw/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following documents, which you should also review before or after training:
+  * [ ] Review the [cloud.gov open source policy guidance about protecting sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).
+  * [ ] Read our [sharing secret keys](https://cloud.gov/docs/ops/secrets/#sharing-secret-keys) policy.
+  * [ ] Review the [TTS requirements for password management](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/password-requirements/).
+* [ ] Read the [Continuous Monitoring Strategy](https://cloud.gov/docs/ops/continuous-monitoring/), particularly the [cloud.gov team responsibilities](https://cloud.gov/docs/ops/continuous-monitoring/#cloud-gov-team).
+* [ ] Read the [Configuration Management Plan](https://cloud.gov/docs/ops/configuration-management/).
+* [ ] Read the [cloud.gov Security Policies and Procedures](https://github.com/cloud-gov/cg-compliance-docs). These documents explain the high-level policies and procedures we must comply with while running cloud.gov, sorted into security control "families" They explain that we follow GSA IT security policy, and they provide a summary of the procedures in our System Security Plan.
+* [ ] Review the System Security Plan (the latest version lives on [Google Drive](https://drive.google.com/drive/u/0/folders/0B6fPl5s12igNX3JwR2xFZVpmek0); look for "cloud.gov System Security Plan (SSP)" as a *.docx* file). Of particular note for onboarding: Section 9 (System Description) and Section 10 (System Environment)
+
+### Getting to know cloud.gov
+
+These items will help you come up to speed on cloud.gov and what it is, how it works, why it exists, etc.  While you
+should take the time to go through them, please do not try and tackle it all in one shot!  It can become overwhelming
+very quickly, so your onboarding buddy will walk through this list with you at a high level with you to help manage the work.
+
+- [ ] Read [the team onboarding document](https://github.com/cloud-gov/product/blob/master/Onboarding.md) for more context about cloud.gov.
+- [ ] Bookmark the [pertinent links listed here](https://github.com/cloud-gov/product/blob/master/PertinentLinks.md).
+- [ ] Read through [the Overview section of our site](https://cloud.gov/docs/overview/what-is-cloudgov/) for a broader understanding of cloud.gov, especially how we present it to potential customers and users.
+- [ ] [Sign up for a cloud.gov sandbox](https://cloud.gov/sign-up/#get-trial-access-and-a-free-sandbox-space) using your GSA email address and start experimenting to get familiar with the basics of the PaaS from a user's perspective.
+  - This is also required in order to make you a platform admin once you've completed the Cybersecurity and Privacy training.
+- [ ] Read the [Delivery Process document](https://github.com/cloud-gov/product/blob/master/StoryLifecycle.md) to learn about how we work.
+- [ ] Read our [service disruption guide](https://cloud.gov/docs/ops/service-disruption-guide/) to learn how we handle customer-facing service disruptions.
+- [ ] Add the [cloud.gov Google Drive folder](https://drive.google.com/drive/folders/0Bx6EvBXVDWwheUtVckVnOE1pRzA) to your Google Drive -- that's where we put cloud.gov docs. If you create or move a doc there, it'll get the right access permissions for team members to be able to view and edit it.
+- [ ] Subscribe to [the cloud.gov team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&amp;ctz=America/Los_Angeles) (click the + in the bottom right) so you know when assorted team meetings are happening in the various squads. Tip: When you plan Out of Office time, make a calendar event for that on the cloud.gov calendar so that your teammates know you'll be away
+
+### Slack channels
+
+Your onboarding buddy will add you to these Slack channels:
+
+- [ ] `#cloud-gov` - bots post announcements here
+- [ ] `#cg-billing` - private business development channel (if applicable)
+- [ ] `#cg-business` - business development (if applicable)
+- [ ] `#cg-compliance` - compliance-related information and discussion
+- [ ] `#cg-offtopic` - off-topic team sharing
+- [ ] `#cg-platform` - platform operations
+- [ ] `#cg-platform-news` - bots post platform alerts
+- [ ] `#cg-general` - program-level information and discusion
+- [ ] `#cg-support` - support requests and assistance within TTS
+- [ ] `#cg-incidents` - private channel for incident response
+- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
+- [ ] `#cg-priv-all` - private channel for in-team discussion
+- [ ] `#cg-priv-gov` (Federal employees only) - may contain discussion of contracting-related or other private, federal-employee-only comms
+
+Once you're added to these channels, you probably want to mute these channels until you're on support rotation:
+
+- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
+- [ ] `#cg-support` - support requests and assistance within TTS
+- [ ] `#cg-platform-news` - platform alerts
+
+## Support-specific items
+
+You should already have admin rights on your machine as a part of its original setup.  If for whatever reason you don't,
+Please let your onboarding buddy know and they will help you request [local admin rights](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit) on your GFE Mac using [this justification](https://docs.google.com/document/d/1YGid3pTji5W_M9RuF1GDf614BVkLIRDmSrt1tDbej-o/edit).
+
+Your onboarding buddy will create a separate ticket tied to this one to track the AWS accounts being granted full admin access.
+
+### Additional compliance setup/review
+
+* [ ] Install `caulking` git leak prevention by following the [README](https://github.com/cloud-gov/caulking/blob/master/README.md)
+* [ ] Verify `caulking` by running `make audit` and pasting a screenshot as a comment on this GitHub issue
+* [ ] Set GPG signing set up for GitHub (instructions [here](https://docs.google.com/document/d/11UDxvfkhncyLEs-NUCniw2u54j4uQBqsR2SBiLYPUZc/edit))
+
+### Install a development environment for cloud.gov
+
+- [ ] Install [Homebrew (`brew`)](https://brew.sh/)
+- [ ] Install [CloudFoundry for mac per their docs](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html#pkg-mac):
+  - `brew tap cloudfoundry/tap`
+  - `brew install cf-cli@7`
+  - `brew install openssl`
+- [ ] Verify CloudFoundry Installation via the CLI (once an existing cloud.gov teammate has [made your cloud.gov admin account](https://cloud.gov/docs/ops/managing-users/#creating-admins))
+  - `cf login -a api.fr.cloud.gov --sso`
+  - `cf orgs`
+    - As a cloud.gov support team member, you should have access to your sandbox; if yoou don't, please reach out to your onboarding buddy

--- a/.github/ISSUE_TEMPLATE/team-member-offboarding.md
+++ b/.github/ISSUE_TEMPLATE/team-member-offboarding.md
@@ -1,29 +1,23 @@
-# Offboarding Checklist
-
-## Instructions
-
-When someone leaves the cloud.gov team
-
-1. The System Owner (director or deputy director) creates a new issue in the private team repo called "Remove [person's name]".
-  If the System Owner cannot do this, the an operations team member can create the issue and include documentation (e.g the screenshot from an authorizing email from SO or their superior)
-2. View the raw source of this file
-3. Copy everything below the line into the new issue's body
-4. Replace "LeavingPerson" with the leaving person's name
-5. Submit the issue
-6. Assign the issue to the person who bravely volunteered to handle the person's offboarding
-7. Put the issue into the "Blocked" column [on our project board](https://github.com/orgs/cloud-gov/projects/2)
+---
+name: Offboard Existing cloud.gov Platform Operations Team Member
+title: Checklist for Offboarding an Existing Platform Operator
+about: This is the checklist and requirements for offboarding an existing platform operator to the cloud.gov team
+labels: ''
+assignees: ''
 
 ---
 
-In order to complete [NAME]'s exit from the cloud.gov team, the assignee should complete a prescribed set of tasks that will remove any special access.
+# Platform Operator Offboarding Checklist
 
-# Directions:
+## Instructions
+
+In order to complete `Existing Person`'s exit from the cloud.gov team, the assignee should complete a prescribed set of tasks that will remove any special access.
 
 **Assignee:** The tasks below are organized by the role needed to complete them. If you can’t complete any of the items on your checklist personally, _you are responsible for ensuring that an appropriate person does it_.
 
-For compliance we need to show that critical offboarding actions happen within 24 hours of departure; some actions below **need GitHub issues comments** when completed. Completing tasks _before_ departure is good. (control PS-4: personnel termination)
+For compliance we need to show that critical offboarding actions happen within 24 hours of departure; some actions below **need GitHub issues comments** when completed. Completing tasks _before_ departure is good. (control PS-4: personnel termination).
 
-## [NAME]
+## `Existing Person`
 
 - [ ] Initiate the process via the [Leaving TTS Handbook page](https://handbook.18f.gov/leaving-tts/)
 

--- a/.github/ISSUE_TEMPLATE/team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/team-member-onboarding.md
@@ -1,32 +1,24 @@
-# Onboarding Checklist
-
-## Instructions
-
-When someone new joins the cloud.gov team:
-
-1. The System Owner (director or deputy director) creates a new issue in the [cg-private Github repo](https://github.com/cloud-gov/private/issues) called "Onboard [NewPerson]".  This constitutes 'formal approval' by leadership.
-  * Use of a private repo and an issue helps satisfy AC-2, that the system owner has added a person to our team before further onboarding.
-  * The system owner must do this step. The assignee can add the checklist if necessary. 
-1. The cloud.gov director or deputy director adds the new team member to the `cloud-gov` team in GitHub. 
-2. Populate the issue with this checklist:
-  2. View the raw source of this file.
-  3. Copy the text before the checklists to the Description field of the card.
-  3. Copy each applicable block of tasks into a its own new task list on the card, replacing `NewPerson` with the new person's name and `Buddy` with the onboarding buddy's name.
-  4. Submit the issue.
-5. Assign the person who bravely volunteered to be the new person's Onboarding Buddy to the issue.
-6. Put the issue into the _Doing_ column.
+---
+name: Onboard New cloud.gov Platform Operations Team Member
+title: Checklist for Onboarding a New Platform Operator
+about: This is the checklist and requirements for onboarding a new platform operator to the cloud.gov team
+labels: ''
+assignees: ''
 
 ---
 
-In order to get `NewPerson` productively contributing to the cloud.gov team, `Buddy` should help `NewPerson` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
+# New Platform Operator Onboarding Checklist
 
-## Directions
+**NOTE:  Do not create this issue until the System Owner has formally authorized and requested it.**
 
-**`NewPerson` and `Buddy`:** Try to go through your checklists in order.
+In order to get `New Person` productively contributing to the cloud.gov team, `Buddy` should help `New Person` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
 
-**`Buddy`:** If you can’t complete any of the items on your checklist personally, _you are responsible for ensuring that someone with the correct access completes that item_.
+## Instructions
 
-## `NewPerson` checklist
+1. Try to go through the checklists in order.
+2. If `Buddy` can’t complete any of the items on their checklist personally, _they are responsible for ensuring that someone with the correct access completes that item_.
+
+## Onboarding Checklist
 
 ### Required items for all team members
 
@@ -50,7 +42,7 @@ These items help us fulfill security and compliance requirements (including for 
 
 #### Learn our policies and procedures
 
-For the three trainings list at the top, `Buddy` will create a separate ticket to track the trainings once scheduling has been finished.  This will help consolidate trainings for multiple new members to the team and prevent them from blocking progress on this onboarding ticket.  Once the trainings are scheduled, they can be marked as complete here.
+For the three trainings list at the top, your onboarding buddy will create a separate ticket to track the trainings once scheduling has been finished.  This will help consolidate trainings for multiple new members to the team and prevent them from blocking progress on this onboarding ticket.  Once the trainings are scheduled, they can be marked as complete here.
 
 * [ ] Coordinate with your onboarding buddy to go through Contingency Planning training within 60 days (and annually after that). This will cover the following document, which you should also review before or after training:
   * [ ] Read the [Contingency Plan](https://docs.cloud.gov/ops/contingency-plan/).
@@ -69,7 +61,7 @@ For the three trainings list at the top, `Buddy` will create a separate ticket t
 
 These items will help you come up to speed on cloud.gov and what it is, how it works, why it exists, etc.  While you
 should take the time to go through them, please do not try and tackle it all in one shot!  It can become overwhelming
-very quickly  `Buddy` will walk through this list with you at a high level with you to help manage the work.
+very quickly, so your onboarding buddy will walk through this list with you at a high level with you to help manage the work.
 
 - [ ] Read [the team onboarding document](https://github.com/cloud-gov/product/blob/master/Onboarding.md) for more context about cloud.gov.
 - [ ] Bookmark the [pertinent links listed here](https://github.com/cloud-gov/product/blob/master/PertinentLinks.md).
@@ -83,7 +75,7 @@ very quickly  `Buddy` will walk through this list with you at a high level with 
 
 ### Slack channels
 
-Your onboarding buddy, `Buddy`, will add you to these Slack channels:
+Your onboarding buddy will add you to these Slack channels:
 
 - [ ] `#cloud-gov` - bots post announcements here
 - [ ] `#cg-billing` - private business development channel (if applicable)
@@ -108,7 +100,7 @@ Once you're added to these channels, you probably want to mute these channels un
 ## Platform-Ops-specific items
 
 You should already have admin rights on your machine as a part of its original setup.  If for whatever reason you don't,
-Please let `Buddy` know and they will help you request [local admin rights](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit) on your GFE Mac using [this justification](https://docs.google.com/document/d/1YGid3pTji5W_M9RuF1GDf614BVkLIRDmSrt1tDbej-o/edit).
+Please let your onboarding buddy know and they will help you request [local admin rights](https://docs.google.com/document/d/1xepZsh83lxPDykrb1NXoeHxj8m78qsdW-9KqzO_CHOQ/edit) on your GFE Mac using [this justification](https://docs.google.com/document/d/1YGid3pTji5W_M9RuF1GDf614BVkLIRDmSrt1tDbej-o/edit).
 
 ### Cloud Operations account management
 
@@ -125,7 +117,7 @@ Please let `Buddy` know and they will help you request [local admin rights](http
 * [ ] Add them to [our dockerhub org](https://hub.docker.com/orgs/cloudgov) and ensure we're not over our license count
 * [ ] Business Unit Only - Add them to the [cloud.gov inquiries Google Group](https://groups.google.com/a/gsa.gov/forum/#!forum/cloud-gov-inquiries) so they can keep apprised of prospective new clients.
 
-`Buddy` will create a separate ticket tied to this one to track the AWS accounts being granted full admin access.
+Your onboarding buddy will create a separate ticket tied to this one to track the AWS accounts being granted full admin access.
 
 ### Additional compliance setup/review
 
@@ -167,7 +159,7 @@ Please let `Buddy` know and they will help you request [local admin rights](http
 
 ### Figure out your first tasks
 
-Please work with your onboarding buddy, `Buddy`, to determine a platform component to work on first.
+Please work with your onboarding buddy to determine a platform component to work on first.
 Once you've identified the component you're going to focus on, your onboarding buddy will introduce
 you to someone who can onboard you to that project in specific. For the next few sprints, work on features,
 bugs, and improvements on this component. Reach out to your onboarding buddy or anyone else on the team 
@@ -185,10 +177,9 @@ if you need any help. Here are some easily-separated pieces to consider:
 - uaa-extras (python + OIDC)
 - shibboleth (Java, OIDC)
 
-## Compliance Lead items
+## Compliance items
 
-These are items that are only necessary for someone stepping into the compliance lead role or a compliance lead support
-role, but you can still subscribe to the alerts and mailing lists if you're interested:
+These are items that are only necessary for someone stepping into a compliance role, but you can still subscribe to the alerts and mailing lists if you're interested:
 
 - [ ] Subscribe to US-CERT alerts: https://us-cert.cisa.gov/mailing-lists-and-feeds
 - [ ] Subscribe to FedRAMP mailing lists: https://public.govdelivery.com/accounts/USGSA/subscriber/topics?qsp=USGSA_2224

--- a/Offboarding.md
+++ b/Offboarding.md
@@ -1,0 +1,12 @@
+# Leaving the cloud.gov team
+
+## Instructions
+
+When someone leaves the cloud.gov team:
+
+
+1. The System Owner (Director or Deputy Director) creates a new issue in the [cg-product Github repo](https://github.com/cloud-gov/product/issues) called "Authorize Offboarding for [ExistingPerson]".  This constitutes 'formal approval' by leadership.
+  - The System Owner must do this step. An assignee can add the checklist afterward if the System Owner hasn't already.
+  - Use of an issue that only the System Owner is authorized to create before offboarding can proceed helps us satisfy the AC-2 control.
+2. The System Owner or an assignee who bravely volunteered to handle the person's offboarding creates a new issue in the [cg-product Github repo](https://github.com/cloud-gov/product/issues) called `System Owner Authorization for Offboarding an Existing Team Member`.
+5. Put the offboarding checklist issue into the _Doing_ column in our [project board](https://github.com/orgs/cloud-gov/projects/2).

--- a/Onboarding.md
+++ b/Onboarding.md
@@ -2,17 +2,27 @@
 
 cloud.gov helps government teams attack core impediments to smooth, iterative deployment of government services, including compliance, security, and scalability. The cloud.gov team develops, operates, and supports cloud.gov so that we can offer it to agencies as a service they can use on their own.
 
+## Instructions
+
+When someone new joins the cloud.gov team:
+
+1. The System Owner (Director or Deputy Director) creates a new issue in the [cg-product Github repo](https://github.com/cloud-gov/product/issues) called "Authorize Onboarding for [NewPerson]".  This constitutes 'formal approval' by leadership.
+  - The System Owner must do this step. An assignee can add the checklist afterward if the System Owner hasn't already.
+  - Use of an issue that only the System Owner is authorized to create before onboarding can proceed helps us satisfy the AC-2 control.
+2. The cloud.gov Director or Deputy Director adds the new team member to the `cloud-gov` team in GitHub.
+3. The System Owner or an assignee creates a new issue in the [cg-product Github repo](https://github.com/cloud-gov/product/issues) called `System Owner Authorization for Onboarding a New Team Member`
+4. The System Owner or the person who bravely volunteered to be the new person's Onboarding Buddy can then proceed to create the onboarding checklist issue for the new person
+5. Put the onboarding checklist issue into the _Doing_ column in our [project board](https://github.com/orgs/cloud-gov/projects/2).
+
 ## Onboarding
+
+Review the [Getting started at TTS guide](https://handbook.tts.gsa.gov/getting-started/) first. (Contractors, we're presuming you have an equivalent process you've gone through for onboarding with your employer.)
 
 Everyone joining the cloud.gov team will get assigned a team onboarding buddy. This person should be working on similar things to what you will be working on, so that they can answer questions in your domain.
 
-You and your team onboarding buddy must follow the instructions in [the Onboarding Checklist](OnboardingChecklist.md) to create an issue that will guide you through tasks that will get you up to speed and contributing in no time. You (and your buddy) must track your progress by checking the boxes as you complete tasks.
+You and your team onboarding buddy must follow the instructions in your onboarding issue that will guide you through tasks that will get you up to speed and contributing in no time. You (and your buddy) must track your progress by checking the boxes as you complete tasks.
 
-Our Onboarding Checklist helps us fulfill important security and compliance requirements, so each new team member needs to have their own checklist in our issue-tracker to document their progress. This is true even if you're rejoining the cloud.gov team after being in it previously.
-
-## How to Tock your time and schedule out-of-office (OOO)
-
-We have [a document outlining our current practices](https://docs.google.com/document/d/16wGnM2vD9y5nrD3Jhufjc-G1r1cs3lkX2Ny-opYk9do/edit#).
+Our onboarding checklists help us fulfill important security and compliance requirements, so each new team member needs to have their own checklist in our issue-tracker to document their progress. This is true even if you're rejoining the cloud.gov team after being in it previously.
 
 ## Tools and project artifacts
 
@@ -73,10 +83,10 @@ Federalist is a platform to build, launch, and manage static web sites for gover
 
 ## Onboarding
 
-Get through [the 18F onboarding guide for your discipline](https://handbook.18f.gov/#teams) first. (Contractors, we're presuming you have an equivalent process you've gone through for onboarding with your employer.)
+Review the [Getting started at TTS guide](https://handbook.tts.gsa.gov/getting-started/) first. (Contractors, we're presuming you have an equivalent process you've gone through for onboarding with your employer.)
 
 Everyone joining the team will get assigned a team onboarding buddy. This person should be working on similar things to what you will be working on, so that they can answer questions in your domain.
 
-You and your team onboarding buddy must follow the instructions in [the Onboarding Checklist](https://docs.google.com/document/d/1tS-9hLb2yHtp500N3obmu0X70XpIMATuPlov2_vDVS0/edit?usp=sharing) to create an issue that will guide you through tasks that will get you up to speed and contributing in no time. You (and your buddy) must track your progress by checking the boxes as you complete tasks.
+You and your team onboarding buddy must follow the instructions in your onboarding issue that will guide you through tasks that will get you up to speed and contributing in no time. You (and your buddy) must track your progress by checking the boxes as you complete tasks.
 
 Our Onboarding Checklist helps us fulfill important security and compliance requirements, so each new team member needs to have their own checklist in our issue-tracker to document their progress. This is true even if you're rejoining the team after being in it previously.


### PR DESCRIPTION
This changeset updates our onboarding and offboarding checklists and issue templates to make it easier to track this work and consolidate all of the information into one location.  We are shifting these processes to be more open and public while strictly adhering to several compliance controls that we must satisfy.

## Changes proposed in this pull request:
- Shifts onboarding checklist into a GitHub issue template
- Creates two new System Owner authorization request issue templates
- Updates the Onboarding and Offboarding guides
- Creates four new team member onboarding issue templates
- Copies the Pages team member onboarding issue template to this repo
- Creates an existing team member offboarding issue template

## Security considerations:
- We are shifting these processes and issues to be created publicly, but are also making sure strict protocol is followed to ensure we're satisfying compliance controls
- Any sensitive information will still be handled separately in a private location