### PR TITLE
Add special notes about names

### DIFF
--- a/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md
@@ -9,7 +9,12 @@ assignees: ''
 
 # New Compliance Team Member Onboarding Checklist
 
-**NOTE:  Do not create this issue until the System Owner has formally authorized and requested it.**
+## Special Notes
+
+- **Do not create this issue until the System Owner has formally authorized and requested it.**
+- **Please only use first names.**
+
+---
 
 In order to get `New Person` productively contributing to the cloud.gov team, `Buddy` should help `New Person` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
 

--- a/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md
@@ -9,7 +9,12 @@ assignees: ''
 
 # New Team Member Onboarding Checklist
 
-**NOTE:  Do not create this issue until the System Owner has formally authorized and requested it.**
+## Special Notes
+
+- **Do not create this issue until the System Owner has formally authorized and requested it.**
+- **Please only use first names.**
+
+---
 
 In order to get `New Person` productively contributing to the cloud.gov team, `Buddy` should help `New Person` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
 

--- a/.github/ISSUE_TEMPLATE/pages-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/pages-team-member-onboarding.md
@@ -1,5 +1,12 @@
  #### User Story
 
+ ## Special Notes
+
+- **Do not create this issue until the System Owner has formally authorized and requested it.**
+- **Please only use first names.**
+
+---
+
 Onboard <Person>
 
 #### Background (Optional)

--- a/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md
@@ -9,7 +9,12 @@ assignees: ''
 
 # New Platform Operator Onboarding Checklist
 
-**NOTE:  Do not create this issue until the System Owner has formally authorized and requested it.**
+## Special Notes
+
+- **Do not create this issue until the System Owner has formally authorized and requested it.**
+- **Please only use first names.**
+
+---
 
 In order to get `New Person` productively contributing to the cloud.gov team, `Buddy` should help `New Person` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
 

--- a/.github/ISSUE_TEMPLATE/so-authorize-offboarding.md
+++ b/.github/ISSUE_TEMPLATE/so-authorize-offboarding.md
@@ -19,6 +19,8 @@ As the System Owner, use this issue template to create a new issue to formally a
 
 Once you create the issue, delete everything from this line and above when you're finished editing so the issue is complete and ready to be acted upon.  It should contain just the message below, with the correct information filled in for the `keywords`.
 
+**NOTE:  Please only use first names when referencing individuals.**
+
 ---
 
 @cloud-gov/platform-ops:

--- a/.github/ISSUE_TEMPLATE/so-authorize-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/so-authorize-onboarding.md
@@ -35,6 +35,8 @@ These are the teams we currently have:
 
 Once you create the issue, delete everything from this line and above when you're finished editing so the issue is complete and ready to be acted upon.  It should contain just the message below, with the correct information filled in for the `keywords`.
 
+**NOTE:  Please only use first names when referencing individuals.**
+
 ---
 
 @cloud-gov/platform-ops:

--- a/.github/ISSUE_TEMPLATE/support-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/support-member-onboarding.md
@@ -9,7 +9,12 @@ assignees: ''
 
 # New Support Team Member Onboarding Checklist
 
-**NOTE:  Do not create this issue until the System Owner has formally authorized and requested it.**
+## Special Notes
+
+- **Do not create this issue until the System Owner has formally authorized and requested it.**
+- **Please only use first names.**
+
+---
 
 In order to get `New Person` productively contributing to the cloud.gov team, `Buddy` should help `New Person` complete a prescribed set of tasks that will bring them up to speed and get them setup with cloud.gov.
 

--- a/.github/ISSUE_TEMPLATE/team-member-offboarding.md
+++ b/.github/ISSUE_TEMPLATE/team-member-offboarding.md
@@ -9,6 +9,13 @@ assignees: ''
 
 # Platform Operator Offboarding Checklist
 
+## Special Notes
+
+- **Do not create this issue until the System Owner has formally authorized and requested it.**
+- **Please only use first names.**
+
+---
+
 ## Instructions
 
 In order to complete `Existing Person`'s exit from the cloud.gov team, the assignee should complete a prescribed set of tasks that will remove any special access.


### PR DESCRIPTION
This changeset adds an additional note to the templates to make sure folks know to use only first names.

## Changes proposed in this pull request:
- Adds a note about using first names only

## Security considerations:
- Since these are becoming public issues, we should only reference folks with first names in the onboarding and offboarding tickets