### PR TITLE
Document the FedRAMP CSP list as a cloud.gov effort

### DIFF
--- a/FedRAMP-CSP-Community.md
+++ b/FedRAMP-CSP-Community.md
@@ -2,6 +2,15 @@
 
 Welcome to the FedRAMP CSP community listserv!
 
+To subscribe: Email listserv@listserv.gsa.gov, the message should 
+have no subject and the body should say only:
+```
+subscribe fedramp-csp-community
+```
+You will then receive address confirmation messages. Then your address
+will be approved (or not) by the moderators.
+
+
 Purpose: Provide a forum for compliance staff at cloud service
 providers (CSPs) that are FedRAMP-authorized, or pursuing FedRAMP
 authorization.

--- a/FedRAMP-CSP-Community.md
+++ b/FedRAMP-CSP-Community.md
@@ -11,8 +11,8 @@ this community as we felt really isolated in our work on POA&Ms,
 Annual Assessments, SCRs, and addressing OMB mandates.
 
 We've started this community to help solve these common problems
-in way that's unrelated to any "competitive advantage." If we can 
-make any process easier for many CSPs, that's win for everyone - 
+in a way that's unrelated to any "competitive advantage." If we can 
+make any process easier for many CSPs, that's win for everyone --
 and especially for the U.S. Government that's consuming these services.
 
 # FedRAMP Compliance Practitioner listserv charter
@@ -20,10 +20,10 @@ and especially for the U.S. Government that's consuming these services.
 Membership: Open to compliance staff at CSPs listed at
 https://marketplace.fedramp.gov as authorized or in-process. If the
 CSP has retained a 3PAO to pursue authorization, they are also
-eligible for participation. 
+eligible for participation. The CSP membership request
+should be forwarded from the 3PAO email domain. 
 
-The TTS cloud.gov compliance team will
-approve memberships.
+The TTS cloud.gov compliance team will approve memberships.
 
 This will be a closed list. Membership and discussions will not be
 published nor searchable, but will be subject to FOIA. Discussions

--- a/FedRAMP-CSP-Community.md
+++ b/FedRAMP-CSP-Community.md
@@ -1,0 +1,43 @@
+# FedRAMP CSP Community
+
+Welcome to the FedRAMP CSP community listserv!
+
+Purpose: Provide a forum for compliance staff at cloud service
+providers (CSPs) that are FedRAMP-authorized, or pursuing FedRAMP
+authorization.
+
+The compliance team at cloud.gov (FedRAMP JAB authorized) started
+this community as we felt really isolated in our work on POA&Ms,
+Annual Assessments, SCRs, and addressing OMB mandates.
+
+We've started this community to help solve these common problems
+in way that's unrelated to any "competitive advantage." If we can 
+make any process easier for many CSPs, that's win for everyone - 
+and especially for the U.S. Government that's consuming these services.
+
+# FedRAMP Compliance Practitioner listserv charter
+
+Membership: Open to compliance staff at CSPs listed at
+https://marketplace.fedramp.gov as authorized or in-process. If the
+CSP has retained a 3PAO to pursue authorization, they are also
+eligible for participation. 
+
+The TTS cloud.gov compliance team will
+approve memberships.
+
+This will be a closed list. Membership and discussions will not be
+published nor searchable, but will be subject to FOIA. Discussions
+are not deemed policy making or advising, as the FedRAMP PMO is not
+participating in the listserv.
+
+The TTS code of conduct will apply.
+
+Notes:
+
+- The listserv is not directly affiliated with FedRAMP. Both FedRAMP
+  and cloud.gov are programs of TTS Solutions, within GSA.
+
+Version history: This charter is in GitHub, and the full version
+history is available there. Major versions:
+
+* 2022-06-17 v0.1 - Draft Charter


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Adds the welcome/readme/charter
- This should go to its own repo if we have more than a single document to manage
- The TTS code of conduct has its critics, but I don't want to go hunting for another one - we can iterate on that.

## security considerations
Open documentation of a non-open service seems okay.
