### PR TITLE
New offboarding process

### DIFF
--- a/.github/ISSUE_TEMPLATE/revoke-access.md
+++ b/.github/ISSUE_TEMPLATE/revoke-access.md
@@ -1,0 +1,24 @@
+---
+name: Remove access for cloud.gov team member
+title: Checklist to revoke critical access for any team member
+labels: ''
+assignees: ''
+
+---
+
+# Checklist to revoke critical access for any team member
+
+When to use this:
+
+* on a team member's last day. Do this first, then continue with generic, low-criticality offboarding.
+  * must be authorized by cloud.gov Director, or any of their superiors within GSA
+* when a team member's identity has been compromised. Do this, then rotate credentials
+  * must accompany an incident tracked by our IR process (link tk), and then
+    be authorized by any two members of CloudOps, TTS Tech Portfolio, and
+    Compliance.
+
+
+Role: Compliance Lead, Engineering Lead, or any DevOps@gsa.gov team member
+System: Break Glas
+Actions: ....
+


### PR DESCRIPTION
## Changes proposed in this pull request:

1. We revoke access consistently on one issue/ticket, and do so within 8 hours.
2. We then can slow-roll the bookkeeping and no-impact systems revocation 

## security considerations
Yes. This needs review to ensure we have a more sustainable and secure offboarding process.

Comments
* I'm starting this issue today because it annoys me were in this situation, and because we have a new process to track. We need to decide if we're doing this this sprint, or when we're scheduling it. But it should be done soon since our current process is kind of broken.
* We should discuss what format makes this most useful in an IR situation so it can be readily followed. As such, it could be folded into our IR rework in 31.2.
