### PR TITLE
Drew onboarding updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md
@@ -92,13 +92,11 @@ Your onboarding buddy will add you to these Slack channels:
 - [ ] `#cg-general` - program-level information and discusion
 - [ ] `#cg-support` - support requests and assistance within TTS
 - [ ] `#cg-incidents` - private channel for incident response
-- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
 - [ ] `#cg-priv-all` - private channel for in-team discussion
 - [ ] `#cg-priv-gov` (Federal employees only) - may contain discussion of contracting-related or other private, federal-employee-only comms
 
 Once you're added to these channels, you probably want to mute these channels until you're on support rotation:
 
-- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
 - [ ] `#cg-support` - support requests and assistance within TTS
 - [ ] `#cg-platform-news` - platform alerts
 

--- a/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md
@@ -29,7 +29,7 @@ In order to get `New Person` productively contributing to the cloud.gov team, `B
 
 These items help us fulfill security and compliance requirements (including for FedRAMP). If you get stuck, or if these requirements are confusing, ask for help from your buddy or in a cloud.gov channel.
 
-- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/.github/ISSUE_TEMPLATE/compliance-team-member-onboarding.md).
 - [ ] Be sure to introduce yourself and follow up with your onboarding buddy (they should have reached out to you at this point; if they haven't, please let the team know) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2). We use this board to organize, prioritize, and track our work.
 
 #### Pre-requisites

--- a/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md
@@ -29,7 +29,7 @@ In order to get `New Person` productively contributing to the cloud.gov team, `B
 
 These items help us fulfill security and compliance requirements (including for FedRAMP). If you get stuck, or if these requirements are confusing, ask for help from your buddy or in a cloud.gov channel.
 
-- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md).
 - [ ] Be sure to introduce yourself and follow up with your onboarding buddy (they should have reached out to you at this point; if they haven't, please let the team know) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2). We use this board to organize, prioritize, and track our work.
 
 #### Pre-requisites

--- a/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/general-team-member-onboarding.md
@@ -92,12 +92,10 @@ Your onboarding buddy will add you to these Slack channels:
 - [ ] `#cg-general` - program-level information and discusion
 - [ ] `#cg-support` - support requests and assistance within TTS
 - [ ] `#cg-incidents` - private channel for incident response
-- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
 - [ ] `#cg-priv-all` - private channel for in-team discussion
 - [ ] `#cg-priv-gov` (Federal employees only) - may contain discussion of contracting-related or other private, federal-employee-only comms
 
 Once you're added to these channels, you probably want to mute these channels until you're on support rotation:
 
-- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
 - [ ] `#cg-support` - support requests and assistance within TTS
 - [ ] `#cg-platform-news` - platform alerts

--- a/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md
@@ -92,13 +92,11 @@ Your onboarding buddy will add you to these Slack channels:
 - [ ] `#cg-general` - program-level information and discusion
 - [ ] `#cg-support` - support requests and assistance within TTS
 - [ ] `#cg-incidents` - private channel for incident response
-- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
 - [ ] `#cg-priv-all` - private channel for in-team discussion
 - [ ] `#cg-priv-gov` (Federal employees only) - may contain discussion of contracting-related or other private, federal-employee-only comms
 
 Once you're added to these channels, you probably want to mute these channels until you're on support rotation:
 
-- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
 - [ ] `#cg-support` - support requests and assistance within TTS
 - [ ] `#cg-platform-news` - platform alerts
 

--- a/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md
@@ -29,7 +29,7 @@ In order to get `New Person` productively contributing to the cloud.gov team, `B
 
 These items help us fulfill security and compliance requirements (including for FedRAMP). If you get stuck, or if these requirements are confusing, ask for help from your buddy or in a cloud.gov channel.
 
-- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/.github/ISSUE_TEMPLATE/platform-ops-member-onboarding.md).
 - [ ] Be sure to introduce yourself and follow up with your onboarding buddy (they should have reached out to you at this point; if they haven't, please let the team know) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2). We use this board to organize, prioritize, and track our work.
 
 #### Pre-requisites

--- a/.github/ISSUE_TEMPLATE/support-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/support-member-onboarding.md
@@ -92,13 +92,11 @@ Your onboarding buddy will add you to these Slack channels:
 - [ ] `#cg-general` - program-level information and discusion
 - [ ] `#cg-support` - support requests and assistance within TTS
 - [ ] `#cg-incidents` - private channel for incident response
-- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
 - [ ] `#cg-priv-all` - private channel for in-team discussion
 - [ ] `#cg-priv-gov` (Federal employees only) - may contain discussion of contracting-related or other private, federal-employee-only comms
 
 Once you're added to these channels, you probably want to mute these channels until you're on support rotation:
 
-- [ ] `#cg-supportstream` - notification channel from our support system, ZenDesk
 - [ ] `#cg-support` - support requests and assistance within TTS
 - [ ] `#cg-platform-news` - platform alerts
 

--- a/.github/ISSUE_TEMPLATE/support-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/support-member-onboarding.md
@@ -29,7 +29,7 @@ In order to get `New Person` productively contributing to the cloud.gov team, `B
 
 These items help us fulfill security and compliance requirements (including for FedRAMP). If you get stuck, or if these requirements are confusing, ask for help from your buddy or in a cloud.gov channel.
 
-- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/OnboardingChecklist.md).
+- [ ] Take judicious notes on what about this onboarding process or cloud.gov is confusing or frustrating. If you notice a problem (especially with things like documentation), you are more than welcome to fix it! At the very least, please share this information with your onboarding buddy (or someone) at some point so we can make the team/platform better. (You can also file issues and pull requests on [the template Onboarding checklist](https://github.com/cloud-gov/product/blob/master/.github/ISSUE_TEMPLATE/support-member-onboarding.md).
 - [ ] Be sure to introduce yourself and follow up with your onboarding buddy (they should have reached out to you at this point; if they haven't, please let the team know) and make sure this issue is assigned to them in our [Github Project Planning Board](https://github.com/orgs/cloud-gov/projects/2). We use this board to organize, prioritize, and track our work.
 
 #### Pre-requisites


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update links to onboarding ticket templates within the template itself
- Remove `#cg-supportstream` slack channel references

## security considerations
None
