### PR TITLE
Remove Mark H

### DIFF
--- a/DeliveryProcess.md
+++ b/DeliveryProcess.md
@@ -12,7 +12,6 @@ We've structured our team into two teams.
   - Van Nguyen
   - Peter Burkholder
   - Andrew Burnes
-  - Mark Headd
   - Mark Boyd
   - Robert Gottlieb
   - James Hochadel


### PR DESCRIPTION
Addresses item in https://github.com/cloud-gov/product/issues/2141

## Changes proposed in this pull request:

- Remove Mark Headd from the squad list.

I also note that this doc needs to be updated to reflect our new squads, but I'm considering that out of scope for this issue.

## security considerations
None. Documentation change only with no sensitive content.
