### PR TITLE
update passive DNS ADR to note logs are stored in Cloudwatch instead of S3

### DIFF
--- a/adr/ADR-0008-passive-dns.md
+++ b/adr/ADR-0008-passive-dns.md
@@ -61,9 +61,4 @@ We should not enable public DNS query logging because the logs are limited in sc
 
 ## Technical implementation
 
-We should send the [resolver query logs to S3](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs-choosing-target-resource.html). In keeping with M-21-31 guidance, we should keep these logs for 30 months and apply the following lifecycle policies:
-
-- 0 - 3 months: S3 standard access
-- 3 - 12 months: S3 Glacier instant retrival
-- 12 - 30 months: S3 Glacier deep archive
-- 30 months: delete
+We should send the [resolver query logs to Cloudwatch](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs-choosing-target-resource.html) so that are easily [searchable from within the AWS console](https://aws.amazon.com/blogs/aws/log-your-vpc-dns-queries-with-route-53-resolver-query-logs/). In keeping with M-21-31 guidance, we should keep these logs for at least 30 months.


### PR DESCRIPTION
## Changes proposed in this pull request:

- update passive DNS ADR to note logs are stored in Cloudwatch instead of S3

## security considerations

None
