### PR TITLE
Add doomsday.fr to our list of management URLS

### DIFF
--- a/cloud.gov-conmon-internal.context
+++ b/cloud.gov-conmon-internal.context
@@ -11,6 +11,7 @@
     <incregexes>https://logs-platform.fr.cloud.gov.*</incregexes>
     <incregexes>https://opslogin.fr.cloud.gov.*</incregexes>
     <incregexes>https://prometheus.fr.cloud.gov.*</incregexes>
+    <incregexes>https://doomsday.fr.cloud.gov.*</incregexes>
     <excregexes>mozilla\.com</excregexes>
     <excregexes>mozilla\.net</excregexes>
     <excregexes>mozilla\.org</excregexes>


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Add missing host, Doomsday
-

## security considerations
Does leak yet another service we have running internally, but seems a minimal risk since there's already a repository for it.
