### PR TITLE
Clarify source of onboarding authorization email links

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboard-compliance.md
+++ b/.github/ISSUE_TEMPLATE/onboard-compliance.md
@@ -16,7 +16,7 @@ assignees: ''
     - [ ] A: System Owner creates this issue
   - B:
     - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
-    - [ ] B.2: An operator downloads a copy of the authorizing email (Open email > Three dots icon > Download) and uploads it to [Google Drive](https://drive.google.com/drive/folders/1OaVhWNp1rTvUrI4-13liz5JCAT4bx869)
+    - [ ] B.2: An operator adds a link to the Google Group conversation that includes the authorizing email.
 - **Please only use first names.**
 
 ---

--- a/.github/ISSUE_TEMPLATE/onboard-compliance.md
+++ b/.github/ISSUE_TEMPLATE/onboard-compliance.md
@@ -12,12 +12,11 @@ assignees: ''
 ## Special Notes
 
 - **Do not create this issue until the System Owner has formally authorized and requested it.**. You can get that OK by one of two ways:
-  A:
-  - [ ] A: System Owner creates this issue
-
-  B:
-  - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
-  - [ ] B.2: An operator adds links to the email archive of the authorizing email.
+  - A:
+    - [ ] A: System Owner creates this issue
+  - B:
+    - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
+    - [ ] B.2: An operator downloads a copy of the authorizing email (Open email > Three dots icon > Download) and uploads it to [Google Drive](https://drive.google.com/drive/folders/1OaVhWNp1rTvUrI4-13liz5JCAT4bx869)
 - **Please only use first names.**
 
 ---

--- a/.github/ISSUE_TEMPLATE/onboard-platform-ops.md
+++ b/.github/ISSUE_TEMPLATE/onboard-platform-ops.md
@@ -16,7 +16,7 @@ assignees: ''
     - [ ] A: System Owner creates this issue
   - B:
     - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
-    - [ ] B.2: An operator downloads a copy of the authorizing email (Open email > Three dots icon > Download) and uploads it to [Google Drive](https://drive.google.com/drive/folders/1OaVhWNp1rTvUrI4-13liz5JCAT4bx869)
+    - [ ] B.2: An operator adds a link to the Google Group conversation that includes the authorizing email.
 - **Please only use first names.**
 
 ---

--- a/.github/ISSUE_TEMPLATE/onboard-platform-ops.md
+++ b/.github/ISSUE_TEMPLATE/onboard-platform-ops.md
@@ -11,13 +11,12 @@ assignees: ''
 
 ## Special Notes
 
-- **Do not create this issue until the System Owner has formally authorized and requested it.** You can obtain that OK by one of two ways:
-  A:
-  - [ ] A: System Owner creates this issue
-
-  B:
-  - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
-  - [ ] B.2: An operator adds links to the email archive of the authorizing email.
+- **Do not create this issue until the System Owner has formally authorized and requested it.**. You can get that OK by one of two ways:
+  - A:
+    - [ ] A: System Owner creates this issue
+  - B:
+    - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
+    - [ ] B.2: An operator downloads a copy of the authorizing email (Open email > Three dots icon > Download) and uploads it to [Google Drive](https://drive.google.com/drive/folders/1OaVhWNp1rTvUrI4-13liz5JCAT4bx869)
 - **Please only use first names.**
 
 ---

--- a/.github/ISSUE_TEMPLATE/onboard-support.md
+++ b/.github/ISSUE_TEMPLATE/onboard-support.md
@@ -16,7 +16,7 @@ assignees: ''
     - [ ] A: System Owner creates this issue
   - B:
     - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
-    - [ ] B.2: An operator downloads a copy of the authorizing email (Open email > Three dots icon > Download) and uploads it to [Google Drive](https://drive.google.com/drive/folders/1OaVhWNp1rTvUrI4-13liz5JCAT4bx869)
+    - [ ] B.2: An operator adds a link to the Google Group conversation that includes the authorizing email.
 - **Please only use first names.**
 
 ---

--- a/.github/ISSUE_TEMPLATE/onboard-support.md
+++ b/.github/ISSUE_TEMPLATE/onboard-support.md
@@ -11,13 +11,12 @@ assignees: ''
 
 ## Special Notes
 
-- **Do not create this issue until the System Owner has formally authorized and requested it.** You can obtain that OK by one of two ways:
-  A:
-  - [ ] A: System Owner creates this issue
-
-  B:
-  - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
-  - [ ] B.2: An operator adds links to the email archive of the authorizing email.
+- **Do not create this issue until the System Owner has formally authorized and requested it.**. You can get that OK by one of two ways:
+  - A:
+    - [ ] A: System Owner creates this issue
+  - B:
+    - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
+    - [ ] B.2: An operator downloads a copy of the authorizing email (Open email > Three dots icon > Download) and uploads it to [Google Drive](https://drive.google.com/drive/folders/1OaVhWNp1rTvUrI4-13liz5JCAT4bx869)
 - **Please only use first names.**
 
 ---

--- a/.github/ISSUE_TEMPLATE/onboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/onboard-team-member.md
@@ -13,10 +13,10 @@ assignees: ''
 
 - **Do not create this issue until the System Owner has formally authorized and requested it.**. You can get that OK by one of two ways:
   - A:
-    - [ ] A: System Owner creates this issue
+    - [ ] A: System Owner creates this issue.
   - B:
-    - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
-    - [ ] B.2: An operator downloads a copy of the authorizing email (Open email > Three dots icon > Download) and uploads it to [Google Drive](https://drive.google.com/drive/folders/1OaVhWNp1rTvUrI4-13liz5JCAT4bx869)
+    - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization.
+    - [ ] B.2: An operator adds a link to the Google Group conversation that includes the authorizing email.
 - **Please only use first names.**
 
 ---

--- a/.github/ISSUE_TEMPLATE/onboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/onboard-team-member.md
@@ -11,13 +11,12 @@ assignees: ''
 
 ## Special Notes
 
-- **Do not create this issue until the System Owner has formally authorized and requested it.** You can obtain that OK by one of two ways:
-  A:
-  - [ ] A: System Owner creates this issue
-
-  B:
-  - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
-  - [ ] B.2: An operator adds links to the email archive of the authorizing email.
+- **Do not create this issue until the System Owner has formally authorized and requested it.**. You can get that OK by one of two ways:
+  - A:
+    - [ ] A: System Owner creates this issue
+  - B:
+    - [ ] B.1: System owner emails cloud-gov-compliance@gsa.gov and cloud-gov-operations@gsa.gov with their authorization
+    - [ ] B.2: An operator downloads a copy of the authorizing email (Open email > Three dots icon > Download) and uploads it to [Google Drive](https://drive.google.com/drive/folders/1OaVhWNp1rTvUrI4-13liz5JCAT4bx869)
 - **Please only use first names.**
 
 ---


### PR DESCRIPTION
## Changes proposed in this pull request:
- Clarify that onboarding authorization links must link to a Google group conversation.
- Links to Gmail only work for the original user, and even then, they may only be temporary. Google Group links are stable over time. 

## security considerations

Since this is only a clarification of the existing process, I think it only needs engineering review.