### PR TITLE
New operators must complete role-based training before system access

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboard-compliance.md
+++ b/.github/ISSUE_TEMPLATE/onboard-compliance.md
@@ -117,7 +117,12 @@ Please let your onboarding buddy know and they will help you request [local admi
 
 ### Cloud Operations account management
 
-*Note: These are all contingent on completing the GSA Mandatory Cyber Security and Privacy Training first. AWS user names should be identical across accounts so that permissions can be correctly managed by Terraform.*
+Before starting this section, you must complete:
+
+1. GSA Mandatory Cyber Security and Privacy Training
+1. Role-based trainings listed under "Learn our policies and procedures"
+
+AWS user names should be identical across accounts so that permissions can be correctly managed by Terraform.
 
 * [ ] Create [AWS Accounts](https://cloud.gov/docs/ops/aws-onboarding/) via the AWS web console (not Terraform) and provide one-time credentials - these will be setup with read-only/auditor permissions, and once the 3 mandatory cloud.gov trainings are complete they will be added to the [audit input file](https://github.com/cloud-gov/cg-compliance/blob/master/audit/inputs.yml):
   * [ ] AWS Commercial accounts

--- a/.github/ISSUE_TEMPLATE/onboard-platform-ops.md
+++ b/.github/ISSUE_TEMPLATE/onboard-platform-ops.md
@@ -134,7 +134,12 @@ In order to install development tools on your Mac, you will need to request loca
 
 ### Cloud Operations account management
 
-_Note: These are all contingent on completing the GSA Mandatory Cyber Security and Privacy Training first. AWS user names should be identical across accounts so that permissions can be correctly managed by Terraform._
+Before starting this section, you must complete:
+
+1. GSA Mandatory Cyber Security and Privacy Training
+1. Role-based trainings listed under "Learn our policies and procedures"
+
+AWS user names should be identical across accounts so that permissions can be correctly managed by Terraform.
 
 - [ ] Create [AWS Accounts](https://cloud.gov/docs/ops/aws-onboarding/) by following [these instructions](https://github.com/cloud-gov/aws-admin/blob/main/docs/user_mgmt.md). These accounts should be setup as read-only at the start, and once the 3 mandatory cloud.gov trainings are complete they will be switched to full admin accounts and added to the [audit input file](https://github.com/cloud-gov/cg-compliance/blob/master/audit/inputs.yml):
   - [ ] AWS Commercial accounts


### PR DESCRIPTION
## Changes proposed in this pull request:

- Addresses CP-3 and IR-2: "We should do a role-based training before privileged access."
- Source: https://gsa-tts.slack.com/archives/C0A1Z7L2U/p1681240530654919?thread_ts=1681226725.509589&cid=C0A1Z7L2U

## security considerations

Aligns onboarding template with controls for new platform operators.
