### PR TITLE
Document use of CG-PRIV

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/offboard-team-member.md
@@ -67,6 +67,7 @@ The following do not directly impact cloud.gov security & operations and can hap
 
 - [ ] Remove them from [Nessus](https://nessus.fr.cloud.gov/#/settings/users)
 - [ ] Remove them from [Tenable (if Compliance Team)](https://community.tenable.com/s/contacts]
+- [ ] Remove them from the [CG-PRIV Space](https://mail.google.com/mail/u/0/#chat/space/AAAAr60JXAc)
 - [ ] Remove them from the [Cloud Foundry Community GitHub org cloud.gov team](https://github.com/orgs/cloudfoundry-community/teams/cloud-gov/members)
 - [ ] Remove them from [the cloud.gov operations Google Group](https://groups.google.com/a/gsa.gov/forum/#!managemembers/cloud-gov-operations/members/active)
 - [ ] Remove them from [the cloud.gov compliance team Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!managemembers/cloud-gov-compliance/members/active)

--- a/.github/ISSUE_TEMPLATE/onboard-platform-ops.md
+++ b/.github/ISSUE_TEMPLATE/onboard-platform-ops.md
@@ -149,6 +149,7 @@ AWS user names should be identical across accounts so that permissions can be co
 - [ ] Add them to the [`platform-ops`](https://github.com/orgs/cloud-gov/teams/platform-ops) team in GitHub.
 - [ ] Add them as an admin on the cg-django-uaa [docs](https://readthedocs.org/projects/cg-django-uaa/)
 - [ ] Add them to [the cloud.gov team Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!forum/cloud-gov) so they can participate in team-wide internal communication.
+- [ ] Add them to the [CG-PRIV Google Space](https://mail.google.com/mail/u/0/#chat/space/AAAAr60JXAc), a fallback team communication channel in the event Slack is down.
 - [ ] Add them to [our dockerhub org](https://hub.docker.com/orgs/cloudgov) and ensure we're not over our license count
 - [ ] Add them as an `agent` to the cloud.gov support Zendesk (Ask a cloud.gov member with admin access to Zendesk to add them).
 - [ ] Add them as Technical users to [Ubuntu Advantage](https://ubuntu.com/pro/users) (Admin users for leads and supervisors) 


### PR DESCRIPTION
## Changes proposed in this pull request:

- I previously removed CG-PRIV from the offboarding because I thought it was a now-defunct Google Group. It is actually a Google Space we use as a backup comms channel in case Slack is down.
- Add CG-PRIV to onboarding and offboarding docs.

## security considerations

Documents use a secure communication channel.
