### PR TITLE
Exclude more sites from conmon

### DIFF
--- a/cloud.gov-conmon-external.context
+++ b/cloud.gov-conmon-external.context
@@ -16,6 +16,12 @@
     <excregexes>mozilla\.org</excregexes>
     <excregexes>firefox\.com</excregexes>
     <excregexes>getpocket\.com</excregexes>
+    <excregexes>cloudflare-dns\.com</excregexes>
+    <excregexes>digitalgov\.gov</excregexes>
+    <excregexes>elastic\.co</excregexes>
+    <excregexes>grafana\.com</excregexes>
+    <excregexes>jsdelivr\.net</excregexes>
+    <excregexes>secureauth\.gsa\.gov</excregexes>
     <tech>
         <include>Db.PostgreSQL</include>
         <include>Db.SQLite</include>

--- a/cloud.gov-conmon-internal.context
+++ b/cloud.gov-conmon-internal.context
@@ -16,6 +16,12 @@
     <excregexes>mozilla\.org</excregexes>
     <excregexes>firefox\.com</excregexes>
     <excregexes>getpocket\.com</excregexes>
+    <excregexes>cloudflare-dns\.com</excregexes>
+    <excregexes>digitalgov\.gov</excregexes>
+    <excregexes>elastic\.co</excregexes>
+    <excregexes>grafana\.com</excregexes>
+    <excregexes>jsdelivr\.net</excregexes>
+    <excregexes>secureauth\.gsa\.gov</excregexes>
     <tech>
         <include>Db.PostgreSQL</include>
         <include>Db.SQLite</include>

--- a/cloud.gov-conmon-pages.context
+++ b/cloud.gov-conmon-pages.context
@@ -13,6 +13,12 @@
         <excregexes>mozilla\.org</excregexes>
         <excregexes>firefox\.com</excregexes>
         <excregexes>getpocket\.com</excregexes>
+        <excregexes>cloudflare-dns\.com</excregexes>
+        <excregexes>digitalgov\.gov</excregexes>
+        <excregexes>elastic\.co</excregexes>
+        <excregexes>grafana\.com</excregexes>
+        <excregexes>jsdelivr\.net</excregexes>
+        <excregexes>secureauth\.gsa\.gov</excregexes>
         <tech>
             <include>Db.MySQL</include>
             <include>Db.PostgreSQL</include>


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Exclude more sites from conmon
-

## security considerations
These site are all out-of-boundary, or managed by other teams (secureauth) so we are safe to exclude them.
