### PR TITLE
Address changes present in ZAP 2.13.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/run_conmon_pages.md
+++ b/.github/ISSUE_TEMPLATE/run_conmon_pages.md
@@ -33,12 +33,13 @@ Each user should have a support user account created in the `zap-scans` organiza
 - Start ZAP and update
   - For "Session persistence", select "No, I do not want to persist my session..."
   - For "Manage add-ons", select "Update All"
+  > NOTE: As of July, 2023 (ZAP 2.13.0) "Manage add-ons" did not pop up automatically and, when opened from the toolbar, rendered the "Update All" button as disabled.
   - ZAP -> Preferences -> Options:
     - JVM -> JVM options: `-Xmx8192m`
     - Active Scan:
       - 3 hosts
       - 5 threads
-    - Global Exclude URL:
+    - Network -> Global Exclusions:
       - Site - Firefox (select all)
       - Site - Font CDNs
       - Site - Mozilla CDN


### PR DESCRIPTION
Updating following #2594 

## Changes proposed in this pull request:
- Add note about the changed behavior of the Manage Add-ons dialog
- Update location of global exclude URLs to reflect changed organization

## security considerations
None. Catching up with ZAP 2.13.0.
