### PR TITLE
Add hint to sync URLs with monitors

### DIFF
--- a/cloud.gov-conmon-external.context
+++ b/cloud.gov-conmon-external.context
@@ -4,6 +4,10 @@
 <name>cloud.gov external conmon</name>
     <desc/>
     <inscope>true</inscope>
+    <!-- 
+      When adding URLs here, sync also with 
+         cg-deploy-prometheus/blob/main/bosh/varsfiles/production.yml
+    -->
     <incregexes>https://account.fr.cloud.gov.*</incregexes>
     <incregexes>https://api.fr.cloud.gov.*</incregexes>
     <incregexes>https://cloud.gov.*</incregexes>

--- a/cloud.gov-conmon-internal.context
+++ b/cloud.gov-conmon-internal.context
@@ -4,6 +4,10 @@
     <name>cloud.gov internal conmon</name>
     <desc/>
     <inscope>true</inscope>
+    <!-- 
+      When adding URLs here, sync also with 
+         cg-deploy-prometheus/blob/main/bosh/varsfiles/production.yml
+    -->
     <incregexes>https://alertmanager.fr.cloud.gov.*</incregexes>
     <incregexes>https://ci.fr.cloud.gov.*</incregexes>
     <incregexes>https://grafana.fr.cloud.gov.*</incregexes>

--- a/cloud.gov-conmon-pages.context
+++ b/cloud.gov-conmon-pages.context
@@ -3,6 +3,10 @@
     <context>
         <name>cloud.gov pages conmon</name>
         <desc/>
+        <!-- 
+          When adding URLs here, sync also with 
+             cg-deploy-prometheus/blob/main/bosh/varsfiles/production.yml
+        -->
         <inscope>true</inscope>
         <incregexes>https://pages-staging.cloud.gov.*</incregexes>
         <incregexes>https://pages.cloud.gov.*</incregexes>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add hint to update prometheus when updating ZAP targets

Question: should we add a hint to update Zap to https://github.com/cloud-gov/cg-deploy-prometheus/blob/main/bosh/varsfiles/production.yml ?

## security considerations
A process comment with no security impact
