### PR TITLE
Fix order of OWASP ZAP settings

### DIFF
--- a/.github/ISSUE_TEMPLATE/run_conmon_pages.md
+++ b/.github/ISSUE_TEMPLATE/run_conmon_pages.md
@@ -35,10 +35,10 @@ Each user should have a support user account created in the `zap-scans` organiza
   - For "Manage add-ons", select "Update All"
   > NOTE: As of July, 2023 (ZAP 2.13.0) "Manage add-ons" did not pop up automatically and, when opened from the toolbar, rendered the "Update All" button as disabled.
   - ZAP -> Settings -> Options:
-    - JVM -> JVM options: `-Xmx8192m`
     - Active Scan:
       - 3 hosts
       - 5 threads
+    - JVM -> JVM options: `-Xmx8192m`
     - Network -> Global Exclusions:
       - Site - Firefox (select all)
       - Site - Font CDNs


### PR DESCRIPTION
The settings to check/change in the Pages ConMon issue template are in a different order from the UI, where they are now alphabetically sorted. This PR corrects the order to match.

This has been bothering me for a while.

## Changes proposed in this pull request:
- Reorder settings in issue template instructions

## security considerations
None. This is a change to procedure documentation which has no functional effect beyond slightly reducing cognitive load.
