### PR TITLE
Updating onboarding template for shared secrets doc link

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboard-any-team-member.md
+++ b/.github/ISSUE_TEMPLATE/onboard-any-team-member.md
@@ -57,7 +57,7 @@ Your onboarding buddy should reach out and introduce themselves to you. If you h
 Onboarding buddy: Contact the compliance team in [#cg-compliance](https://gsa.enterprise.slack.com/archives/C0A1Z7L2U) to schedule training(s).
 
 - [ ] Coordinate with your onboarding buddy to schedule [nonpublic information training](https://docs.google.com/presentation/d/1uB4MlGCu8ZYUxjKVZKwicQ95MvLxaT4Mh93y6w79GPw/edit#slide=id.p) within 60 days of joining the team (and annually after that). This will cover the following documents, which you should also review before or after training:
-  - [ ] Read our [sharing secret keys](https://cloud.gov/docs/ops/secrets/#sharing-secret-keys) policy.
+  - [ ] Read our sharing secret keys policy.  Your onboarding buddy can provide you the internal docs link to access.
   - [ ] Review the [TTS requirements for password management](https://handbook.tts.gsa.gov/general-information-and-resources/tech-policies/password-requirements/).
 
 ## Getting to know cloud.gov


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove old CG-Site link and adjust verbage to have buddy provide the link to internal docs

## security considerations
We moved the team docs to a private repo and don't want to expose the repo name in a public repo
