### PR TITLE
Add customer quotes

### DIFF
--- a/customerQuotes.md
+++ b/customerQuotes.md
@@ -1,0 +1,133 @@
+# Unattributed Customer Quotes
+
+_Gathered during GSA's 2024 Customer Loyalty Survey or among internal customers at TTS/GSA in Slack in early 2025._
+
+> "cloud.gov is one of the first GSA tools I used and I liked it, then met the people behind it, then loved it. When I argued for feds doing tech work and running services, cloud.gov is the bulk of my examples, and are a primary reason I wanted back into TTS."
+
+> "I have always been intrigued by cloud.gov when I first heard of it. This will sound silly, but I took multiple CloundFoundry trainings and passed certs a few years because I loved what this platform has been doing for government after getting to use it, for free in sandbox, as a contractor one day with no strings attached on my first few days rolling onto a project. Who does that in government!? Answer: no one really but cloud.gov."
+
+> "I worked with some of you closely and even the ideas that were not really usable you worked with me to iterate and understand how and why to do it better. I have applied to work in cloud.gov as a fed because I love what and how you provide value to the USG and citizens. I have a very passionate view on GS civil servants doing the work and how wrong other stereotypes of feds are, and it 99% of the time goes back to cloud.gov, with receipts, because I cite the GitHub issues, PRs, and code. Thanks for inspiring me!"
+
+> "Getting to join a cloud.gov incident retro a year or two back and being able to learn from one another was incredibly helpful. [Our team] doesn’t use cloud.gov outside of Pages much today, though I’d like to, but we still benefit immensely from having smart people operating a large platform nearby."
+
+> "Everyone I’ve ever interacted with on cloud.gov is incredibly helpful whenever we’ve had an issue (and often before we do too!)"
+
+> "You probably already know this, but I am a huge fan of cloud.gov. It continues to have a huge positive impact on my experience as a developer, making it quick to iterate ideas, and easy to deploy changes for partners. I have also always been so impressed by the level of quick and knowledgeable customer support I have received from cloud.gov folks."
+
+> "The whole Cloud.gov team does work that supports... hundreds? thousands? millions? Hundreds of developers are glad their code has a rock-solid foundation underneath them, so they can focus on delivering their applications for the public. Thousands of Federal users---perhaps even tens-of-thousands or more---rely on those services to do their day-to-day work. Millions of members of the public use those services as they go about their days. The work you do is invisible to most and invaluable to those who see. Thank you."
+
+> "Cloud.gov's documentation keeps getting better and better! (For some reason I keep finding things I need in https://cloud.gov/docs/compliance/domain-standards/, does that make me a weirdo?)"
+
+> "When I contact cloud.gov support, I feel confident that I'm going to get help. I'm keenly aware of this because I usually don't feel that way about technical support."
+
+> "cloud.gov started because it was too large to launch and manage apps for a small team at GSA. Now its a relied-on tool for agencies across government - thanks to your work. People can find their way because you are keeping the lights on."
+
+> "It's not just the services the CG team provides, but the manner of support and engagement that is human which I rely on."
+
+> "Cloud.gov is just the right balance between “You can do anything you want, but you have to do it all yourself” and “You can only do this one thing that is allowed”. It’s such a sweet spot to be able to spin up a web application just with a “cf push”. Someone recently asked me “can you spin up that prototype we worked on a year ago so I could get some screenshots” and I told them “I’ll try, but it might take me a while” and then it was up and running again in my sandbox in less than 5 mintues."
+
+> "Cloud.gov makes things easy for us to build. We built [our project] on top of cloud.gov pages and platform, and were able to focus our requirements to whatever we needed from the application vs needing to worry about hosting and infrastructure.
+> We were successful in no small part because cloud.gov provided the environment for us to make it happen and were incredibly responsive when we needed help."
+
+> "Right off the bat I freaking love the service in general. The projects I've been on where I can just push a branch up and share the link in moments is so convenient and saves so much time. I've never worked on a project in the private sector that had a similar setup and it rules. So, thanks for the team for setting that up and making my (developer) life easy. Also your shared 11ty USWDS template is an awesome starter."
+
+> "Support is ALWAYS quick and helpful."
+
+> "Our interactions with cloud.gov have significantly streamlined our ATO process, which has been a major benefit this year. The automatic handling of vulnerabilities has provided peace of mind and saved us considerable time and effort. Additionally, the ease of adding new applications has made it much simpler to scale our operations and respond to new requirements. We also appreciate how responsive Cloud.gov has been to our requests. Overall, cloud.gov has made our day to day work easier and more efficient."
+
+> "By using cloud.gov's hosting, we get the benefit of cloud.gov's DDOS protections and don't have to build and manage that ourselves. I've also found that cloud.gov's support has been very responsive over the past year, both formally and informally."
+
+> "Cloud.gov is the reason that our extremely popular [redacted] website is able to withstand surges in traffic during wildfire and smoke episodes."
+
+> "Monitoring logs and usage data, managing user access to orgs and spaces made interactions with cloud.gov easier this year."
+
+> "Their rapid response of helpdesk questions has been tremendously helpful when we have issues that arise."
+
+> "The support team at cloud.gov are always incredibly quick to respond."
+
+> "Cloud.gov's sandboxes are a major help for figuring out what is possible."
+
+> "The Cloud.gov team has consistently been responsive to our inquiries and concerns. Whether we encountered technical issues or needed assistance with onboarding, their support team was readily available to provide guidance and solutions. Overall, our experience with the Cloud.gov team has been positive, and we look forward to continued collaboration and growth with them in the future."
+
+> "Hands-on support. Cloud.gov makes it so agencies don't need experienced infrastructure engineers to launch an application on modern infrastructure. I understand the focus of cloud.gov to be on providing an easy to use, fedramped system, with cloud.gov support for infrastructure issues. I think you're excelling on this, and I understand the trade-offs in power / flexibility that come with that."
+
+> "The sandbox account has been a great resource for quickly getting prototypes up. Alongside the other cloud service sandbox accounts available to us in TTS, Cloud.gov is generally the first choice, due to ATO and organizational efficiencies."
+
+> "Everything has been great! The platform is intuitive and provides great feedback for any of our needs. The documentation is thorough and if anything is unclear customer support is quick to respond."
+
+> "cloud.gov support team is amazing. They always respond quickly. The platform is setup very well which further reduce the need for any help from support."
+
+> "We have an extremely wide traffic need (middling low to insanely high during certain events) and cloud.gov can accommodate both with flat, budget-friendly billing, and includes access to high tools (CDN) within the flat rate."
+
+> "The fact that we can deploy and host our applications on cloud.gov makes our lives and work much easier!  We can spin up our new app versions very easily, troubleshoot our issues with access to the logs, and if we have any questions or issues we can easily reach out to cloud.gov support."
+
+> "All of the information I need to do my job is easily accessible.  The cloud.gov public documentation, the public GitHub repos and project board, and the CF portal.  Also any questions I've sent to the support team are always addressed promptly and in a satisfactory way."
+
+> "Pricing is pretty good.   Ease of use is very high and there is a great deal of flexibility in the system.   We can do our work with a minimum of overhead, all the while knowing that our solution is FEDRAMP-compliant and supportive of the US Government's IT policies."
+
+> "Cloud.gov seems to provide a large set of services under one very reasonable price point, I feel like it allows easier acquisition of enterprise-class services at a lower knowledge threshold by the obtainer of services (i.e. me and other users of cloudgov) at the expense of taking away some options-- which I think is a solid choice."
+
+> "Cloud.gov provides some of the best documentation I've found, which is a big help. We understand better what we can do than I've experienced with other platforms."
+
+> "I really appreciate the work cloud.gov does to provide DDoS protection for us. We're a small team and having someone provide that service helps me sleep better."
+
+> "Having now experienced launching government services on ~FCS~ other government infrastructure, I am completely in awe. I'm not sure I have words for how much better the experience is. Everything just works. Everything is at my fingertips. I don't have operate my infrastructure via voice command that I have to create a calendar event to use."
+## Pages
+
+> "Every project I’ve worked on in 5+ years as a fed has involved Cloud in one way or another—mostly Pages (née Federalist), but not all. When I was new here, and didn’t really know how to build stuff in government, it was so reassuring to have Cloud there as not just the “right” choice from budgeting and compliance perspectives, but also being an easy platform to get up and running on. If Cloud & Pages never added another feature from when I started using them way back then, I still wouldn’t have any hesitation about using them. But y’all didn’t rest on being the right and easy choice. Y’all have continued to make great stuff that improves the lives of those of us who make federal government websites, but by adding features to improve accessibility and security of Cloud-hosted products, also makes the public’s experience of government services better. And that’s what we’re all here to do, isn’t it?"
+
+> "Pages is fantastic for managing small, static websites... we rely on the Pages platform and Github to ensure security as our Page's hosted sites are simple static content-based sites. "
+
+> "Launching prototypes on Pages has moved entire projects forward in the past. Hosting static sites on Pages furnishes so much flexibility...frankly, it allows so many options to avoid vendor lock-in, since hosting isn't wrapped up with a vendor."
+
+> "Pages made it easy to start with a static page outlining the timeline and milestones, and direct people to more help, then build up from there as we launched the service and started full-scale support activity for people using it. Rapidly updating our static docs to account for new sources of confusion was easy and straightforward, and was just never an issue for the team."
+
+> "Pages makes it very easy to build, deploy, and update our websites without worrying about infrastructure. This enables us to deliver results rapidly."
+
+> "Cloud.gov Pages makes prototyping websites really easy to deploy to a shareable location. Additionally, it's nice to do more complicated application development in Cloud.gov itself, rather than having to fuss with setting up an appropriate AWS environment and do all the configuration myself."
+
+> "Pages has been a great tool for prototyping websites for partners and this ease has lead to many partners choosing to continue using the tool in production. We can spin up a a basic site in minutes with very little outside help. The self-service aspect of Pages has been critical for us to work quickly to validate idea with programs and users. The easy integration with GitHub has also been valuable — especially branch previews which allow us to work in staging/demo environments and validate work before going live. We have also benefited from the flexibility Pages allows in choosing tools. It was very easy to deploy pages using newer frameworks like Astro following Pages documentation."
+
+> "Providing a simple service allowing agencies to responsibly serve content on the Internet with minimal startup and ongoing costs. Pages eats complexity and allows for customers to leverage many controls. While it might take ~100 lines of Terraform to serve a static web site out of AWS, it takes 500+ pages of SSP and hundreds of hours to be allowed to serve the site."
+
+> "Customer support from Pages has been outstanding. We have benefited from the ease of getting in touch via Slack and email and truly appreciate that we can speak directly to engineers with deep knowledge of the service.
+> Pages has also been very dependable. After using the service for several years, I cannot think of a single failure or technical problem effecting users that can be attributed to the platform.
+> Pages has done a nice job keeping things simple for users too. The UI for seeing builds is great feature and makes it easy to view build progress and logs when we need to."
+
+> "The Cloud.gov and Cloud.gov Pages teams have been clear and helpful communicators, responsive, and always willing to jump on a call to collaborate on issues.  When we’ve hit roadblocks, they’ve been proactive in offering up alternate approaches, saving us time and frustration."
+
+> "I really appreciate how narrowly tailored the Pages offering is. It is very easy to get approval for using it and to get an ATO because it's a known quantity for our agency ISSOs. Even when we're using Pages as part of a more complex system, with more complex compliance requirements, having a static site deployment that's straightforward to document and assess is great."
+
+> "Pages gets our new sites up faster than anything I’ve used in the private sector and the team is always so fast and helpful in fixing issues. Thank you!"
+
+> "Cloud.gov Pages makes prototyping websites really easy to deploy to a shareable location. Additionally, it's nice to do more complicated application development in Cloud.gov itself, rather than having to fuss with setting up an appropriate AWS environment and do all the configuration myself."
+
+> "I can view individual builds to troubleshoot errors. As well as manually triggering rebuilds. The default environment variables also make it easy to work with in different environments."
+
+> "[Cloud.gov Pages makes my work] Easier by managing all aspects of deployments. It is especially nice to be able to preview branch changes."
+
+> "Pages (and Cloud.gov in general) are the best thing to happen to civtech in a very long time."
+
+> "[Cloud.gov Pages] made it much easier to publish a website and make changes to it."
+
+> "I can view individual builds to troubleshoot errors. As well as manually triggering rebuilds. The default environment variables also make it easy to work with in different environments."
+
+> "In many ways, Pages is a "set it and forget it" tool...once configured, it generally just works for our digital team members."
+
+> "Updating our website is as easy as submitting a pull request to GitHub and configuration values are easily modified in the site settings."
+
+> "[Pages] made it much easier to publish a website and make changes to it."
+
+> "Easier by managing all aspects of deployments. It is especially nice to be able to preview branch changes."
+
+> "Easier - Pages is makes it so much less burdensome to serve sites. The abstractions and automations are very good."
+
+> "The Pages folks are really helpful and responsive. Makes troubleshooting issues easier."
+
+> "Responding to technical concerns, providing support, keeping a solid platform up and running consistently."
+
+> ""Making deployment effortless. Removing the burden of maintaining and allocating website infrastructure."
+
+
+
+

--- a/customerQuotes.md
+++ b/customerQuotes.md
@@ -2,76 +2,92 @@
 
 _Gathered during GSA's 2024 Customer Loyalty Survey, from Customer Feedback sessions in late 2024, and among internal customers at TTS/GSA in Slack in early 2025._
 
-> "cloud.gov is one of the first GSA tools I used and I liked it, then met the people behind it, then loved it. When I argued for feds doing tech work and running services, cloud.gov is the bulk of my examples, and are a primary reason I wanted back into TTS."
+> "Cloud.gov is one of the first GSA tools I used and I liked it, then met the people behind it, then loved it. When I argued for feds doing tech work and running services, Cloud.gov is the bulk of my examples, and are a primary reason I wanted back into TTS."
 
-> "I have always been intrigued by cloud.gov when I first heard of it. This will sound silly, but I took multiple CloundFoundry trainings and passed certs a few years because I loved what this platform has been doing for government after getting to use it, for free in sandbox, as a contractor one day with no strings attached on my first few days rolling onto a project. Who does that in government!? Answer: no one really but cloud.gov."
+> "I have always been intrigued by Cloud.gov when I first heard of it. This will sound silly, but I took multiple Cloud Foundry trainings and passed certs a few years because I loved what this platform has been doing for government after getting to use it, for free in sandbox, as a contractor one day with no strings attached on my first few days rolling onto a project. Who does that in government!? Answer: no one really but Cloud.gov."
 
-> "I worked with some of you closely and even the ideas that were not really usable you worked with me to iterate and understand how and why to do it better. I have applied to work in cloud.gov as a fed because I love what and how you provide value to the USG and citizens. I have a very passionate view on GS civil servants doing the work and how wrong other stereotypes of feds are, and it 99% of the time goes back to cloud.gov, with receipts, because I cite the GitHub issues, PRs, and code. Thanks for inspiring me!"
+> "I worked with some of you closely and even the ideas that were not really usable you worked with me to iterate and understand how and why to do it better. I have applied to work in Cloud.gov as a fed because I love what and how you provide value to the USG and citizens. I have a very passionate view on GS civil servants doing the work and how wrong other stereotypes of feds are, and it 99% of the time goes back to Cloud.gov, with receipts, because I cite the GitHub issues, PRs, and code. Thanks for inspiring me!"
 
-> "Getting to join a cloud.gov incident retro a year or two back and being able to learn from one another was incredibly helpful. [Our team] doesn’t use cloud.gov outside of Pages much today, though I’d like to, but we still benefit immensely from having smart people operating a large platform nearby."
+> "Getting to join a Cloud.gov incident retro a year or two back and being able to learn from one another was incredibly helpful. [Our team] doesn’t use Cloud.gov outside of Pages much today, though I’d like to, but we still benefit immensely from having smart people operating a large platform nearby."
 
-> "Everyone I’ve ever interacted with on cloud.gov is incredibly helpful whenever we’ve had an issue (and often before we do too!)"
+> "Everyone I’ve ever interacted with on Cloud.gov is incredibly helpful whenever we’ve had an issue (and often before we do too!)"
 
-> "You probably already know this, but I am a huge fan of cloud.gov. It continues to have a huge positive impact on my experience as a developer, making it quick to iterate ideas, and easy to deploy changes for partners. I have also always been so impressed by the level of quick and knowledgeable customer support I have received from cloud.gov folks."
+> "You probably already know this, but I am a huge fan of Cloud.gov. It continues to have a huge positive impact on my experience as a developer, making it quick to iterate ideas, and easy to deploy changes for partners. I have also always been so impressed by the level of quick and knowledgeable customer support I have received from Cloud.gov folks."
 
 > "The whole Cloud.gov team does work that supports... hundreds? thousands? millions? Hundreds of developers are glad their code has a rock-solid foundation underneath them, so they can focus on delivering their applications for the public. Thousands of Federal users---perhaps even tens-of-thousands or more---rely on those services to do their day-to-day work. Millions of members of the public use those services as they go about their days. The work you do is invisible to most and invaluable to those who see. Thank you."
 
 > "Cloud.gov's documentation keeps getting better and better! (For some reason I keep finding things I need in https://cloud.gov/docs/compliance/domain-standards/, does that make me a weirdo?)"
 
-> "When I contact cloud.gov support, I feel confident that I'm going to get help. I'm keenly aware of this because I usually don't feel that way about technical support."
+> "When I contact Cloud.gov support, I feel confident that I'm going to get help. I'm keenly aware of this because I usually don't feel that way about technical support."
 
-> "cloud.gov started because it was too large to launch and manage apps for a small team at GSA. Now its a relied-on tool for agencies across government - thanks to your work. People can find their way because you are keeping the lights on."
+> "Cloud.gov started because it was too large to launch and manage apps for a small team at GSA. Now its a relied-on tool for agencies across government - thanks to your work. People can find their way because you are keeping the lights on."
 
-> "It's not just the services the CG team provides, but the manner of support and engagement that is human which I rely on."
+> "It's not just the services the [Cloud.gov] team provides, but the manner of support and engagement that is human which I rely on."
 
-> "Cloud.gov is just the right balance between “You can do anything you want, but you have to do it all yourself” and “You can only do this one thing that is allowed”. It’s such a sweet spot to be able to spin up a web application just with a “cf push”. Someone recently asked me “can you spin up that prototype we worked on a year ago so I could get some screenshots” and I told them “I’ll try, but it might take me a while” and then it was up and running again in my sandbox in less than 5 mintues."
+> "Cloud.gov is just the right balance between “You can do anything you want, but you have to do it all yourself” and “You can only do this one thing that is allowed”. It’s such a sweet spot to be able to spin up a web application just with a “cf push”. Someone recently asked me “can you spin up that prototype we worked on a year ago so I could get some screenshots” and I told them “I’ll try, but it might take me a while” and then it was up and running again in my sandbox in less than 5 minutes."
 
-> "Cloud.gov makes things easy for us to build. We built [our project] on top of cloud.gov pages and platform, and were able to focus our requirements to whatever we needed from the application vs needing to worry about hosting and infrastructure.
-> We were successful in no small part because cloud.gov provided the environment for us to make it happen and were incredibly responsive when we needed help."
+> "Cloud.gov makes things easy for us to build. We built [our project] on top of Cloud.gov pages and platform, and were able to focus our requirements to whatever we needed from the application vs needing to worry about hosting and infrastructure.
+> We were successful in no small part because Cloud.gov provided the environment for us to make it happen and were incredibly responsive when we needed help."
 
 > "Right off the bat I freaking love the service in general. The projects I've been on where I can just push a branch up and share the link in moments is so convenient and saves so much time. I've never worked on a project in the private sector that had a similar setup and it rules. So, thanks for the team for setting that up and making my (developer) life easy. Also your shared 11ty USWDS template is an awesome starter."
 
 > "Support is ALWAYS quick and helpful."
 
-> "Our interactions with cloud.gov have significantly streamlined our ATO process, which has been a major benefit this year. The automatic handling of vulnerabilities has provided peace of mind and saved us considerable time and effort. Additionally, the ease of adding new applications has made it much simpler to scale our operations and respond to new requirements. We also appreciate how responsive Cloud.gov has been to our requests. Overall, cloud.gov has made our day to day work easier and more efficient."
+> "Our interactions with Cloud.gov have significantly streamlined our ATO process, which has been a major benefit this year. The automatic handling of vulnerabilities has provided peace of mind and saved us considerable time and effort. Additionally, the ease of adding new applications has made it much simpler to scale our operations and respond to new requirements. We also appreciate how responsive Cloud.gov has been to our requests. Overall, Cloud.gov has made our day to day work easier and more efficient."
 
-> "By using cloud.gov's hosting, we get the benefit of cloud.gov's DDOS protections and don't have to build and manage that ourselves. I've also found that cloud.gov's support has been very responsive over the past year, both formally and informally."
+> "By using Cloud.gov's hosting, we get the benefit of Cloud.gov's DDOS protections and don't have to build and manage that ourselves. I've also found that Cloud.gov's support has been very responsive over the past year, both formally and informally."
 
 > "Cloud.gov is the reason that our extremely popular [redacted] website is able to withstand surges in traffic during wildfire and smoke episodes."
 
-> "Monitoring logs and usage data, managing user access to orgs and spaces made interactions with cloud.gov easier this year."
+> "Monitoring logs and usage data, managing user access to orgs and spaces made interactions with Cloud.gov easier this year."
 
 > "Their rapid response of helpdesk questions has been tremendously helpful when we have issues that arise."
 
-> "The support team at cloud.gov are always incredibly quick to respond."
+> "The support team at Cloud.gov are always incredibly quick to respond."
 
 > "Cloud.gov's sandboxes are a major help for figuring out what is possible."
 
 > "The Cloud.gov team has consistently been responsive to our inquiries and concerns. Whether we encountered technical issues or needed assistance with onboarding, their support team was readily available to provide guidance and solutions. Overall, our experience with the Cloud.gov team has been positive, and we look forward to continued collaboration and growth with them in the future."
 
-> "Hands-on support. Cloud.gov makes it so agencies don't need experienced infrastructure engineers to launch an application on modern infrastructure. I understand the focus of cloud.gov to be on providing an easy to use, fedramped system, with cloud.gov support for infrastructure issues. I think you're excelling on this, and I understand the trade-offs in power / flexibility that come with that."
+> "Hands-on support. Cloud.gov makes it so agencies don't need experienced infrastructure engineers to launch an application on modern infrastructure. I understand the focus of Cloud.gov to be on providing an easy to use, FedRAMP'd system, with Cloud.gov support for infrastructure issues. I think you're excelling on this, and I understand the trade-offs in power / flexibility that come with that."
 
 > "The sandbox account has been a great resource for quickly getting prototypes up. Alongside the other cloud service sandbox accounts available to us in TTS, Cloud.gov is generally the first choice, due to ATO and organizational efficiencies."
 
 > "Everything has been great! The platform is intuitive and provides great feedback for any of our needs. The documentation is thorough and if anything is unclear customer support is quick to respond."
 
-> "cloud.gov support team is amazing. They always respond quickly. The platform is setup very well which further reduce the need for any help from support."
+> "Cloud.gov support team is amazing. They always respond quickly. The platform is setup very well which further reduce the need for any help from support."
 
-> "We have an extremely wide traffic need (middling low to insanely high during certain events) and cloud.gov can accommodate both with flat, budget-friendly billing, and includes access to high tools (CDN) within the flat rate."
+> "We have an extremely wide traffic need (middling low to insanely high during certain events) and Cloud.gov can accommodate both with flat, budget-friendly billing, and includes access to high tools (CDN) within the flat rate."
 
-> "The fact that we can deploy and host our applications on cloud.gov makes our lives and work much easier!  We can spin up our new app versions very easily, troubleshoot our issues with access to the logs, and if we have any questions or issues we can easily reach out to cloud.gov support."
+> "The fact that we can deploy and host our applications on Cloud.gov makes our lives and work much easier!  We can spin up our new app versions very easily, troubleshoot our issues with access to the logs, and if we have any questions or issues we can easily reach out to Cloud.gov support."
 
-> "All of the information I need to do my job is easily accessible.  The cloud.gov public documentation, the public GitHub repos and project board, and the CF portal.  Also any questions I've sent to the support team are always addressed promptly and in a satisfactory way."
+> "All of the information I need to do my job is easily accessible.  The Cloud.gov public documentation, the public GitHub repos and project board, and the CF portal.  Also any questions I've sent to the support team are always addressed promptly and in a satisfactory way."
 
-> "Pricing is pretty good.   Ease of use is very high and there is a great deal of flexibility in the system.   We can do our work with a minimum of overhead, all the while knowing that our solution is FEDRAMP-compliant and supportive of the US Government's IT policies."
+> "Pricing is pretty good.   Ease of use is very high and there is a great deal of flexibility in the system.   We can do our work with a minimum of overhead, all the while knowing that our solution is FedRAMP-compliant and supportive of the US Government's IT policies."
 
-> "Cloud.gov seems to provide a large set of services under one very reasonable price point, I feel like it allows easier acquisition of enterprise-class services at a lower knowledge threshold by the obtainer of services (i.e. me and other users of cloudgov) at the expense of taking away some options-- which I think is a solid choice."
+> "Cloud.gov seems to provide a large set of services under one very reasonable price point, I feel like it allows easier acquisition of enterprise-class services at a lower knowledge threshold by the obtainer of services (i.e. me and other users of Cloud.gov) at the expense of taking away some options-- which I think is a solid choice."
 
 > "Cloud.gov provides some of the best documentation I've found, which is a big help. We understand better what we can do than I've experienced with other platforms."
 
-> "I really appreciate the work cloud.gov does to provide DDoS protection for us. We're a small team and having someone provide that service helps me sleep better."
+> "I really appreciate the work Cloud.gov does to provide DDoS protection for us. We're a small team and having someone provide that service helps me sleep better."
 
 > "Having now experienced launching government services on ~FCS~ other government infrastructure, I am completely in awe. I'm not sure I have words for how much better the experience is. Everything just works. Everything is at my fingertips. I don't have operate my infrastructure via voice command that I have to create a calendar event to use."
+
+> "Cloud.gov has been great to deal with and would agree we are swimming with the current when using the platform."
+
+> "Cloud.gov remains one of the top (if not the top) [agency-approved] custom application hosting environments."
+
+> "Seamless maintenance and application uptime is big plus and greatly appreciated"
+
+> "We love Cloud.gov. If we didn't have Cloud.gov, we'd have to hire like six more people"
+
+> "For us, Cloud.gov is like the duck on a pond, we see it  moving placidly along, but under the water there is a lot of work going on.
+
+> "A strength of Cloud.gov is how easy it is to make applications go live. It
+> took one day to push an application as a proof of concept on Cloud.gov which exceeded their expectations."
+
+> "One of the biggest benefits of Cloud.gov is the ceiling on billing in AWS"
+
 ## Pages
 
 > "Every project I’ve worked on in 5+ years as a fed has involved Cloud in one way or another—mostly Pages (née Federalist), but not all. When I was new here, and didn’t really know how to build stuff in government, it was so reassuring to have Cloud there as not just the “right” choice from budgeting and compliance perspectives, but also being an easy platform to get up and running on. If Cloud & Pages never added another feature from when I started using them way back then, I still wouldn’t have any hesitation about using them. But y’all didn’t rest on being the right and easy choice. Y’all have continued to make great stuff that improves the lives of those of us who make federal government websites, but by adding features to improve accessibility and security of Cloud-hosted products, also makes the public’s experience of government services better. And that’s what we’re all here to do, isn’t it?"
@@ -128,20 +144,6 @@ _Gathered during GSA's 2024 Customer Loyalty Survey, from Customer Feedback sess
 
 > "Making deployment effortless. Removing the burden of maintaining and allocating website infrastructure."
 
-> "Cloud.gov has been great to deal with and would agree we are swimming with the current when using the platform."
-
-> "Cloud.gov remains one of the top (if not the top) [agency-approved] custom application hosting environments."
-
-> "Seamless maintenance and application uptime is big plus and greatly appreciated"
-
-> "We love Cloud.gov. If we didn't have Cloud.gov, we'd have to hire like six more people"
-
-> "For us, Cloud.gov is like the duck on a pond, we see it  moving placidly along, but under the water there is a lot of work going on.
-
-> "A strength of Cloud.gov is how easy it is to make applications go live. It
-> took one day to push an application as a proof of concept on Cloud.gov which exceeded their expectations."
-
-> "One of the biggest benefits of Cloud.gov is the ceiling on billing in AWS"
 
 
 

--- a/customerQuotes.md
+++ b/customerQuotes.md
@@ -71,22 +71,21 @@ _Gathered during GSA's 2024 Customer Loyalty Survey, from Customer Feedback sess
 
 > "I really appreciate the work Cloud.gov does to provide DDoS protection for us. We're a small team and having someone provide that service helps me sleep better."
 
-> "Having now experienced launching government services on ~FCS~ other government infrastructure, I am completely in awe. I'm not sure I have words for how much better the experience is. Everything just works. Everything is at my fingertips. I don't have operate my infrastructure via voice command that I have to create a calendar event to use."
+> "Having now experienced launching government services on other government infrastructure, I am completely in awe. I'm not sure I have words for how much better the experience is. Everything just works. Everything is at my fingertips. I don't have operate my infrastructure via voice command that I have to create a calendar event to use."
 
 > "Cloud.gov has been great to deal with and would agree we are swimming with the current when using the platform."
 
 > "Cloud.gov remains one of the top (if not the top) [agency-approved] custom application hosting environments."
 
-> "Seamless maintenance and application uptime is big plus and greatly appreciated"
+> "Seamless maintenance and application uptime is big plus and greatly appreciated."
 
-> "We love Cloud.gov. If we didn't have Cloud.gov, we'd have to hire like six more people"
+> "We love Cloud.gov. If we didn't have Cloud.gov, we'd have to hire like six more people."
 
 > "For us, Cloud.gov is like the duck on a pond, we see it  moving placidly along, but under the water there is a lot of work going on.
 
-> "A strength of Cloud.gov is how easy it is to make applications go live. It
-> took one day to push an application as a proof of concept on Cloud.gov which exceeded their expectations."
+> "A strength of Cloud.gov is how easy it is to make applications go live. It took one day to push an application as a proof of concept on Cloud.gov which exceeded their expectations."
 
-> "One of the biggest benefits of Cloud.gov is the ceiling on billing in AWS"
+> "One of the biggest benefits of Cloud.gov is the ceiling on billing in AWS."
 
 ## Pages
 
@@ -143,10 +142,3 @@ _Gathered during GSA's 2024 Customer Loyalty Survey, from Customer Feedback sess
 > "Responding to technical concerns, providing support, keeping a solid platform up and running consistently."
 
 > "Making deployment effortless. Removing the burden of maintaining and allocating website infrastructure."
-
-
-
-
-
-
-

--- a/customerQuotes.md
+++ b/customerQuotes.md
@@ -1,6 +1,6 @@
 # Unattributed Customer Quotes
 
-_Gathered during GSA's 2024 Customer Loyalty Survey or among internal customers at TTS/GSA in Slack in early 2025._
+_Gathered during GSA's 2024 Customer Loyalty Survey, from Customer Feedback sessions in late 2024, and among internal customers at TTS/GSA in Slack in early 2025._
 
 > "cloud.gov is one of the first GSA tools I used and I liked it, then met the people behind it, then loved it. When I argued for feds doing tech work and running services, cloud.gov is the bulk of my examples, and are a primary reason I wanted back into TTS."
 
@@ -126,7 +126,24 @@ _Gathered during GSA's 2024 Customer Loyalty Survey or among internal customers 
 
 > "Responding to technical concerns, providing support, keeping a solid platform up and running consistently."
 
-> ""Making deployment effortless. Removing the burden of maintaining and allocating website infrastructure."
+> "Making deployment effortless. Removing the burden of maintaining and allocating website infrastructure."
+
+> "Cloud.gov has been great to deal with and would agree we are swimming with the current when using the platform."
+
+> "Cloud.gov remains one of the top (if not the top) [agency-approved] custom application hosting environments."
+
+> "Seamless maintenance and application uptime is big plus and greatly appreciated"
+
+> "We love Cloud.gov. If we didn't have Cloud.gov, we'd have to hire like six more people"
+
+> "For us, Cloud.gov is like the duck on a pond, we see it  moving placidly along, but under the water there is a lot of work going on.
+
+> "A strength of Cloud.gov is how easy it is to make applications go live. It
+> took one day to push an application as a proof of concept on Cloud.gov which exceeded their expectations."
+
+> "One of the biggest benefits of Cloud.gov is the ceiling on billing in AWS"
+
+
 
 
 


### PR DESCRIPTION
Wanted to gather these recent sanitized customer comments about cloud.gov and Pages somewhere that the team can easily find. 

## Changes proposed in this pull request:
- Saves usable customer quotes in a place the team can easily find

## security considerations
- redacted all team/project names